### PR TITLE
feat(game): economy & market (#11)

### DIFF
--- a/src/game/market.ts
+++ b/src/game/market.ts
@@ -1,0 +1,152 @@
+import { getCharacter, applySellPriceModifier } from './characters'
+
+export interface MarketPrice {
+  cityId: number
+  alcoholType: string
+  price: number
+  demandIndex: number
+}
+
+export interface YearEvent {
+  id: string
+  name: string
+  description: string
+  priceMultiplier?: number   // multiply all city prices (e.g. 0.7 = Great Depression)
+  heatDelta?: number         // flat heat added citywide (e.g. 20 = Police Crackdown)
+  productionBonus?: number   // flat production units bonus per still
+}
+
+/** Base sell value per alcohol type (in dollars per unit) */
+export const ALCOHOL_BASE_VALUES: Record<string, number> = {
+  moonshine: 10,
+  vodka:     18,
+  rum:       20,
+  bourbon:   30,
+  gin:       30
+}
+
+/** Historical event cards drawn at season 1 of each year */
+export const YEAR_EVENTS: YearEvent[] = [
+  {
+    id: 'great_depression',
+    name: 'The Great Depression',
+    description: 'Economic collapse — all city alcohol prices drop 30%.',
+    priceMultiplier: 0.7
+  },
+  {
+    id: 'police_crackdown',
+    name: 'Police Crackdown',
+    description: 'Authorities intensify raids — +20 Heat in every city.',
+    heatDelta: 20
+  },
+  {
+    id: 'border_closure',
+    name: 'Border Closure',
+    description: 'Import routes disrupted — prices for imported spirits rise 25%.',
+    priceMultiplier: 1.25
+  },
+  {
+    id: 'repeal_rumor',
+    name: 'Repeal Rumor',
+    description: 'Whispers of Prohibition ending — demand surges, prices +20%.',
+    priceMultiplier: 1.2
+  },
+  {
+    id: 'treasury_raid',
+    name: 'Treasury Raid',
+    description: 'Federal agents raid major suppliers — +15 Heat everywhere.',
+    heatDelta: 15
+  },
+  {
+    id: 'bumper_harvest',
+    name: 'Bumper Harvest',
+    description: 'Grain surplus floods the market — prices drop 15%.',
+    priceMultiplier: 0.85
+  },
+  {
+    id: 'speakeasy_boom',
+    name: 'Speakeasy Boom',
+    description: 'Underground bars proliferate — demand spikes, prices +30%.',
+    priceMultiplier: 1.3
+  },
+  {
+    id: 'labor_strike',
+    name: 'Labor Strike',
+    description: 'Transport workers walk out — production halted, +4 units per still.',
+    productionBonus: 4
+  },
+  {
+    id: 'women_temperance',
+    name: "Women's Temperance March",
+    description: 'Public pressure rises — +25 Heat citywide.',
+    heatDelta: 25
+  },
+  {
+    id: 'mild_winter',
+    name: 'Mild Winter',
+    description: 'Easy travel conditions — no effect this year.',
+    priceMultiplier: 1.0
+  }
+]
+
+/**
+ * Calculate the sale price for alcohol in a city.
+ * Formula: basePrice × distance × demandIndex, floored.
+ */
+export function calculateCityPrice(
+  basePrice: number,
+  distance: number,
+  demandIndex: number
+): number {
+  return Math.floor(basePrice * distance * demandIndex)
+}
+
+/**
+ * Apply character sell modifiers to a city price.
+ * - Pharmacist: 1.5× when selling moonshine ("Medicinal Spirits")
+ * - Socialite: 1.15× on any type
+ */
+export function applySellModifier(
+  price: number,
+  characterClass: string,
+  alcoholType: string
+): number {
+  const char = getCharacter(characterClass)
+  if (!char) return price
+
+  // Pharmacist sells moonshine as Medicinal Spirits at medicinalPriceMultiplier
+  if (characterClass === 'pharmacist' && alcoholType === 'moonshine') {
+    return Math.floor(price * char.modifiers.medicinalPriceMultiplier)
+  }
+
+  return Math.round(applySellPriceModifier(characterClass, price))
+}
+
+/**
+ * If more than 1 player vehicle is present in the city, prices drop 50%.
+ */
+export function applyCompetitionPenalty(price: number, playerCount: number): number {
+  if (playerCount > 1) return Math.floor(price * 0.5)
+  return price
+}
+
+/** Draw a random year event card */
+export function rollYearEvent(): YearEvent {
+  return YEAR_EVENTS[Math.floor(Math.random() * YEAR_EVENTS.length)]
+}
+
+/**
+ * Apply a year event's price multiplier to a base price.
+ * Returns price unchanged if the event has no priceMultiplier.
+ */
+export function applyYearEvent(price: number, event: YearEvent): number {
+  if (event.priceMultiplier === undefined) return price
+  return Math.floor(price * event.priceMultiplier)
+}
+
+/**
+ * Generate a Global Volatility Index for the year: a random float in [0.7, 1.3].
+ */
+export function generateVolatilityIndex(): number {
+  return 0.7 + Math.random() * 0.6
+}

--- a/src/routes/games.ts
+++ b/src/routes/games.ts
@@ -38,6 +38,20 @@ gamesRouter.post('/:id/start', async (c) => {
   return c.json({ success: true })
 })
 
+gamesRouter.get('/:id/market', async (c) => {
+  const gameId = c.req.param('id')
+  const { results: prices } = await c.env.PROHIBITIONDB.prepare(
+    `SELECT mp.city_id, mp.alcohol_type, mp.price, mp.season,
+            gc.demand_index
+     FROM market_prices mp
+     JOIN game_cities gc ON mp.city_id = gc.id
+     WHERE mp.game_id = ?
+     ORDER BY mp.city_id, mp.alcohol_type`
+  ).bind(gameId).all()
+
+  return c.json({ success: true, data: { prices } })
+})
+
 gamesRouter.get('/:id/map', async (c) => {
   const gameId = c.req.param('id')
   const { results: cities } = await c.env.PROHIBITIONDB.prepare(

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALCOHOL_BASE_VALUES,
+  YEAR_EVENTS,
+  calculateCityPrice,
+  applySellModifier,
+  applyCompetitionPenalty,
+  rollYearEvent,
+  applyYearEvent,
+  generateVolatilityIndex,
+  type MarketPrice,
+  type YearEvent
+} from '../src/game/market'
+
+describe('ALCOHOL_BASE_VALUES', () => {
+  it('defines moonshine, vodka, rum, bourbon, gin', () => {
+    expect(ALCOHOL_BASE_VALUES.moonshine).toBeDefined()
+    expect(ALCOHOL_BASE_VALUES.vodka).toBeDefined()
+    expect(ALCOHOL_BASE_VALUES.rum).toBeDefined()
+    expect(ALCOHOL_BASE_VALUES.bourbon).toBeDefined()
+    expect(ALCOHOL_BASE_VALUES.gin).toBeDefined()
+  })
+
+  it('moonshine is cheapest, bourbon/gin are most expensive', () => {
+    const vals = ALCOHOL_BASE_VALUES
+    expect(vals.moonshine).toBeLessThan(vals.vodka)
+    expect(vals.vodka).toBeLessThanOrEqual(vals.rum)
+    expect(vals.bourbon).toBeGreaterThanOrEqual(vals.rum)
+    expect(vals.gin).toBeGreaterThanOrEqual(vals.rum)
+  })
+})
+
+describe('YEAR_EVENTS', () => {
+  it('defines at least 8 distinct events', () => {
+    expect(YEAR_EVENTS.length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('each event has id, name, description, and at least one effect', () => {
+    for (const event of YEAR_EVENTS) {
+      expect(event.id).toBeTruthy()
+      expect(event.name).toBeTruthy()
+      expect(event.description).toBeTruthy()
+      // must have at least one numeric effect
+      const hasEffect = event.priceMultiplier !== undefined || event.heatDelta !== undefined || event.productionBonus !== undefined
+      expect(hasEffect).toBe(true)
+    }
+  })
+})
+
+describe('calculateCityPrice()', () => {
+  it('multiplies base price by distance and demand index', () => {
+    // basePrice=10, distance=2, demandIndex=1.5 → 30
+    expect(calculateCityPrice(10, 2, 1.5)).toBeCloseTo(30)
+  })
+
+  it('returns base price when distance=1 and demandIndex=1.0', () => {
+    expect(calculateCityPrice(20, 1, 1.0)).toBeCloseTo(20)
+  })
+
+  it('floors the result', () => {
+    // 10 * 1.5 * 1.3 = 19.5 → 19
+    expect(calculateCityPrice(10, 1.5, 1.3)).toBe(19)
+  })
+})
+
+describe('applySellModifier()', () => {
+  it('returns base price for neutral character', () => {
+    expect(applySellModifier(100, 'bootlegger', 'bourbon')).toBe(100)
+  })
+
+  it('applies Socialite +15% sell bonus', () => {
+    expect(applySellModifier(100, 'socialite', 'bourbon')).toBeCloseTo(115)
+  })
+
+  it('applies Pharmacist 1.5× for medicinal spirits (moonshine)', () => {
+    expect(applySellModifier(100, 'pharmacist', 'moonshine')).toBeCloseTo(150)
+  })
+
+  it('applies only generic sellPriceMultiplier for Pharmacist on non-moonshine', () => {
+    // pharmacist has medicinal=1.5 for moonshine, but standard 1.0 sellPriceMultiplier for others
+    expect(applySellModifier(100, 'pharmacist', 'bourbon')).toBeCloseTo(100)
+  })
+})
+
+describe('applyCompetitionPenalty()', () => {
+  it('returns price unchanged when only 1 player present', () => {
+    expect(applyCompetitionPenalty(100, 1)).toBe(100)
+  })
+
+  it('drops price 50% when >1 player vehicles present', () => {
+    expect(applyCompetitionPenalty(100, 2)).toBe(50)
+    expect(applyCompetitionPenalty(200, 3)).toBe(100)
+  })
+})
+
+describe('rollYearEvent()', () => {
+  it('returns a valid year event', () => {
+    const event = rollYearEvent()
+    const ids = YEAR_EVENTS.map(e => e.id)
+    expect(ids).toContain(event.id)
+  })
+})
+
+describe('applyYearEvent()', () => {
+  it('scales prices when event has priceMultiplier', () => {
+    const event: YearEvent = { id: 'test', name: 'Test', description: 'x', priceMultiplier: 0.7 }
+    expect(applyYearEvent(100, event)).toBe(70)
+  })
+
+  it('returns price unchanged when no priceMultiplier', () => {
+    const event: YearEvent = { id: 'test', name: 'Test', description: 'x', heatDelta: 10 }
+    expect(applyYearEvent(100, event)).toBe(100)
+  })
+})
+
+describe('generateVolatilityIndex()', () => {
+  it('returns a value between 0.7 and 1.3', () => {
+    for (let i = 0; i < 20; i++) {
+      const v = generateVolatilityIndex()
+      expect(v).toBeGreaterThanOrEqual(0.7)
+      expect(v).toBeLessThanOrEqual(1.3)
+    }
+  })
+})


### PR DESCRIPTION
## Description
Per-city supply/demand market with distance pricing, Global Volatility Index, and year event cards.

## Changes
- Alcohol base values: moonshine $10 → bourbon/gin $30
- `calculateCityPrice()`: basePrice × distance × demandIndex
- `applySellModifier()`: Pharmacist 1.5× medicinal spirits, Socialite +15%
- `applyCompetitionPenalty()`: -50% when >1 player present
- `generateVolatilityIndex()`: random [0.7–1.3] annual modifier
- 10 YEAR_EVENTS including Great Depression, Police Crackdown, Speakeasy Boom
- `GET /api/games/:id/market` endpoint

## Testing
- [x] 17 tests added, all 111 passing
- [x] TypeScript clean

Closes #11