### PR TITLE
feat(game): police & heat system (#12)

### DIFF
--- a/src/game/police.ts
+++ b/src/game/police.ts
@@ -1,0 +1,145 @@
+import { applyHeatModifier, getCharacter } from './characters'
+import { rollDice } from './movement'
+
+export type HeatEvent =
+  | 'cargo_travel'
+  | 'double_cross_success'
+  | 'double_cross_fail'
+  | 'hostile_takeover'
+  | 'run_fail'
+
+export type PopulationTier = 'small' | 'medium' | 'large' | 'major'
+
+export interface EncounterContext {
+  currentHeat: number
+  alcoholUnits: number
+  cashOnHand: number
+}
+
+export interface SubmitResult {
+  alcoholSeized: number
+  cashSeized: number
+  heatDelta: number
+}
+
+export interface RunResult {
+  escaped: boolean
+  jailSeasons: number
+  heatDelta: number
+}
+
+export interface BribeResult {
+  cashPaid: number
+  cleared: boolean
+}
+
+/** Canonical heat deltas for each event */
+export const HEAT_CHANGES = {
+  cargoTravel:        2,
+  doubleCrossSuccess: 10,
+  doubleCrossFail:    20,
+  hostileTakeover:    15,
+  runFail:            30,
+  idleDecay:          -5,   // per idle season
+  moneyLaunder:       -25   // Social Club money laundering
+} as const
+
+/** Heat added per distillery tier per season */
+export const TIER_PASSIVE_HEAT: Record<number, number> = { 1: 1, 2: 2, 3: 4, 4: 7, 5: 12 }
+
+/** Bribe multiplier by city size */
+const TIER_BRIBE_MULTIPLIER: Record<PopulationTier, number> = {
+  small:  1.0,
+  medium: 1.5,
+  large:  2.5,
+  major:  4.0
+}
+
+/**
+ * Delta to add to heat for a specific event.
+ * Applies character heat multiplier (Priest/Nun −25%).
+ */
+export function calculateHeatIncrease(event: HeatEvent, characterClass: string): number {
+  const base: Record<HeatEvent, number> = {
+    cargo_travel:         HEAT_CHANGES.cargoTravel,
+    double_cross_success: HEAT_CHANGES.doubleCrossSuccess,
+    double_cross_fail:    HEAT_CHANGES.doubleCrossFail,
+    hostile_takeover:     HEAT_CHANGES.hostileTakeover,
+    run_fail:             HEAT_CHANGES.runFail
+  }
+  const raw = applyHeatModifier(characterClass, base[event])
+  return Math.min(100, Math.max(0, raw))
+}
+
+/**
+ * Heat lost per season.
+ * Priest/Nun decay 2×; money laundering adds an extra 25-point drop.
+ */
+export function calculateHeatDecay(characterClass: string, laundering: boolean): number {
+  const char = getCharacter(characterClass)
+  const decayMultiplier = char?.modifiers.heatDecayMultiplier ?? 1.0
+  let decay = Math.abs(HEAT_CHANGES.idleDecay) * decayMultiplier
+  if (laundering) decay += Math.abs(HEAT_CHANGES.moneyLaunder)
+  return Math.floor(decay)
+}
+
+/**
+ * Returns true if a police encounter occurs.
+ * Formula: Random(0,100) < currentHeat
+ */
+export function rollPoliceEncounter(currentHeat: number): boolean {
+  return Math.random() * 100 < currentHeat
+}
+
+/**
+ * Resolve a Submit choice.
+ * Low heat (<30): nothing found.
+ * High heat (>=50): seize all alcohol + 50% cash.
+ * Mid heat (30-49): seize half alcohol, no cash.
+ */
+export function resolveSubmit(currentHeat: number, alcoholUnits: number, cashOnHand: number): SubmitResult {
+  if (currentHeat < 30) {
+    return { alcoholSeized: 0, cashSeized: 0, heatDelta: -5 }
+  }
+  if (currentHeat >= 50) {
+    return {
+      alcoholSeized: alcoholUnits,
+      cashSeized:    Math.floor(cashOnHand * 0.5),
+      heatDelta:     -10
+    }
+  }
+  return { alcoholSeized: Math.floor(alcoholUnits / 2), cashSeized: 0, heatDelta: -5 }
+}
+
+/** Resolve a spot Bribe — pay and go. */
+export function resolveBribe(bribeCost: number): BribeResult {
+  return { cashPaid: bribeCost, cleared: true }
+}
+
+/**
+ * Resolve a Run attempt.
+ * Roll 2d6: beat 8 → escape (heat +5 for the chase), fail → Jail 2 seasons (+30 heat).
+ */
+export function resolveRun(roll: number): RunResult {
+  if (roll > 8) {
+    return { escaped: true, jailSeasons: 0, heatDelta: 5 }
+  }
+  return { escaped: false, jailSeasons: 2, heatDelta: HEAT_CHANGES.runFail }
+}
+
+/**
+ * One-time spot bribe cost: scales with current heat and city size.
+ */
+export function calculateSpotBribeCost(currentHeat: number, tier: PopulationTier): number {
+  const base = 50 + currentHeat * 2
+  return Math.floor(base * TIER_BRIBE_MULTIPLIER[tier])
+}
+
+/**
+ * Long-term city bribe cost: more expensive than spot, scales with city size.
+ * Lasts 4 seasons (6 for Vixen — applied externally via applyBribeDuration).
+ */
+export function calculateLongTermBribeCost(tier: PopulationTier): number {
+  const base = 500
+  return Math.floor(base * TIER_BRIBE_MULTIPLIER[tier])
+}

--- a/tests/police.test.ts
+++ b/tests/police.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateHeatIncrease,
+  calculateHeatDecay,
+  rollPoliceEncounter,
+  resolveSubmit,
+  resolveBribe,
+  resolveRun,
+  calculateSpotBribeCost,
+  calculateLongTermBribeCost,
+  type EncounterContext,
+  HEAT_CHANGES
+} from '../src/game/police'
+
+describe('HEAT_CHANGES', () => {
+  it('defines all heat change constants', () => {
+    expect(HEAT_CHANGES.cargoTravel).toBeGreaterThan(0)
+    expect(HEAT_CHANGES.doubleCrossSuccess).toBeGreaterThan(0)
+    expect(HEAT_CHANGES.doubleCrossFail).toBeGreaterThan(HEAT_CHANGES.doubleCrossSuccess)
+    expect(HEAT_CHANGES.hostileTakeover).toBeGreaterThan(0)
+    expect(HEAT_CHANGES.idleDecay).toBeLessThan(0)
+    expect(HEAT_CHANGES.moneyLaunder).toBeLessThan(0)
+    expect(HEAT_CHANGES.runFail).toBeGreaterThan(0)
+  })
+})
+
+describe('calculateHeatIncrease()', () => {
+  it('returns cargoTravel delta when moving with cargo', () => {
+    const delta = calculateHeatIncrease('cargo_travel', 'bootlegger')
+    expect(delta).toBe(HEAT_CHANGES.cargoTravel)
+  })
+
+  it('applies Priest/Nun heat reduction', () => {
+    const base = calculateHeatIncrease('cargo_travel', 'bootlegger')
+    const reduced = calculateHeatIncrease('cargo_travel', 'priest_nun')
+    expect(reduced).toBeLessThan(base)
+  })
+
+  it('clamps result between 0 and 100', () => {
+    const delta = calculateHeatIncrease('hostile_takeover', 'bootlegger')
+    expect(delta).toBeGreaterThanOrEqual(0)
+    expect(delta).toBeLessThanOrEqual(100)
+  })
+})
+
+describe('calculateHeatDecay()', () => {
+  it('returns idle decay for standard character', () => {
+    const decay = calculateHeatDecay('bootlegger', false)
+    expect(decay).toBe(Math.abs(HEAT_CHANGES.idleDecay))
+  })
+
+  it('doubles decay for Priest/Nun', () => {
+    const standard = calculateHeatDecay('bootlegger', false)
+    const fast = calculateHeatDecay('priest_nun', false)
+    expect(fast).toBeGreaterThan(standard)
+  })
+
+  it('applies money launder bonus when laundering', () => {
+    const normal = calculateHeatDecay('bootlegger', false)
+    const laundered = calculateHeatDecay('bootlegger', true)
+    expect(laundered).toBeGreaterThan(normal)
+  })
+})
+
+describe('rollPoliceEncounter()', () => {
+  it('returns true (encounter) when heat > 75', () => {
+    // With heat = 100 the threshold is always exceeded
+    let encounters = 0
+    for (let i = 0; i < 20; i++) {
+      if (rollPoliceEncounter(100)) encounters++
+    }
+    expect(encounters).toBe(20)
+  })
+
+  it('returns false (no encounter) when heat = 0', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(rollPoliceEncounter(0)).toBe(false)
+    }
+  })
+})
+
+describe('resolveSubmit()', () => {
+  it('no penalty when heat is low (<30)', () => {
+    const result = resolveSubmit(20, 50, 10)
+    expect(result.alcoholSeized).toBe(0)
+    expect(result.cashSeized).toBe(0)
+  })
+
+  it('seizes all alcohol and 50% cash when heat is high (>=50)', () => {
+    const result = resolveSubmit(80, 50, 200)
+    expect(result.alcoholSeized).toBe(50)
+    expect(result.cashSeized).toBe(100)
+  })
+})
+
+describe('resolveBribe()', () => {
+  it('returns the bribe cost as cash paid', () => {
+    const result = resolveBribe(200)
+    expect(result.cashPaid).toBe(200)
+    expect(result.cleared).toBe(true)
+  })
+})
+
+describe('resolveRun()', () => {
+  it('escapes when roll > 8', () => {
+    const result = resolveRun(9)
+    expect(result.escaped).toBe(true)
+    expect(result.jailSeasons).toBe(0)
+  })
+
+  it('goes to jail for 2 seasons when roll <= 8', () => {
+    const result = resolveRun(6)
+    expect(result.escaped).toBe(false)
+    expect(result.jailSeasons).toBe(2)
+  })
+})
+
+describe('calculateSpotBribeCost()', () => {
+  it('returns a positive cost scaling with heat', () => {
+    const low = calculateSpotBribeCost(20, 'small')
+    const high = calculateSpotBribeCost(80, 'major')
+    expect(high).toBeGreaterThan(low)
+    expect(low).toBeGreaterThan(0)
+  })
+})
+
+describe('calculateLongTermBribeCost()', () => {
+  it('returns cost > spot bribe cost', () => {
+    const spot = calculateSpotBribeCost(50, 'large')
+    const longTerm = calculateLongTermBribeCost('large')
+    expect(longTerm).toBeGreaterThan(spot)
+  })
+
+  it('scales with population tier', () => {
+    const small = calculateLongTermBribeCost('small')
+    const major = calculateLongTermBribeCost('major')
+    expect(major).toBeGreaterThan(small)
+  })
+})


### PR DESCRIPTION
## Description
Full police encounter and heat management system.

## Changes
- `HEAT_CHANGES` constants for all heat-generating events
- `rollPoliceEncounter()`: triggers on `Random(0,100) < currentHeat`
- Three encounter choices: Submit (tiers by heat level), Spot Bribe, Run (2d6 beat 8)
- Jail: 2 seasons on failed run
- `calculateHeatDecay()`: Priest/Nun 2× decay, money laundering -25 bonus
- Bribe costs scale by city population tier (small → major ×1–4)
- `TIER_PASSIVE_HEAT` per distillery upgrade tier

## Testing
- [x] 17 tests added, all 128 passing
- [x] TypeScript clean

Closes #12