### PR TITLE
feat(game): city ownership & takeovers (#14)

### DIFF
--- a/src/game/cityOwnership.ts
+++ b/src/game/cityOwnership.ts
@@ -1,0 +1,77 @@
+import { applyTakeoverCostModifier } from './characters'
+
+export type PopulationTier = 'small' | 'medium' | 'large' | 'major'
+
+export interface OwnedCity {
+  cityId: number
+  populationTier: PopulationTier
+  isCoastal: boolean
+  marketValue: number   // current city market price (base for tax calculations)
+  ownerId: number | null
+}
+
+/** Base city buy prices by population tier */
+const BASE_BUY_PRICE: Record<PopulationTier, number> = {
+  small:  500,
+  medium: 1000,
+  large:  2500,
+  major:  6000
+}
+
+/** Protection tax rate as a fraction of market value */
+const PROTECTION_TAX_RATE = 0.1
+
+/** Takeover premium multiplier over the neutral buy price */
+const TAKEOVER_PREMIUM = 1.5
+
+/** Cities with population tier >= 'large' count as '>50k' for Jazz Singer income */
+const JAZZ_INCOME_TIERS = new Set<PopulationTier>(['large', 'major'])
+const JAZZ_INCOME_AMOUNT: Record<PopulationTier, number> = {
+  small:  0,
+  medium: 0,
+  large:  50,
+  major:  100
+}
+
+/**
+ * Price to purchase a neutral city outright.
+ */
+export function calculateBuyPrice(city: OwnedCity): number {
+  return BASE_BUY_PRICE[city.populationTier]
+}
+
+/**
+ * Price to perform a Hostile Takeover of a rival-owned city.
+ * = buyPrice × TAKEOVER_PREMIUM × characterTakeoverCostMultiplier
+ */
+export function calculateTakeoverPrice(city: OwnedCity, characterClass: string): number {
+  const base = calculateBuyPrice(city) * TAKEOVER_PREMIUM
+  return Math.floor(applyTakeoverCostModifier(characterClass, base))
+}
+
+/**
+ * Protection Tax collected per owned city per season.
+ * Based on PROTECTION_TAX_RATE × marketValue.
+ * Jailed owners collect at 50% penalty.
+ */
+export function calculateProtectionTax(city: OwnedCity, ownerInJail: boolean): number {
+  const full = Math.floor(city.marketValue * PROTECTION_TAX_RATE)
+  return ownerInJail ? Math.floor(full * 0.5) : full
+}
+
+/**
+ * Passive income for Jazz Singer in cities with population > 50k.
+ * Returns 0 for all other characters, or small/medium cities.
+ */
+export function calculateJazzPassiveIncome(characterClass: string, city: OwnedCity): number {
+  if (characterClass !== 'jazz_singer') return 0
+  if (!JAZZ_INCOME_TIERS.has(city.populationTier)) return 0
+  return JAZZ_INCOME_AMOUNT[city.populationTier]
+}
+
+/**
+ * True when the player has enough cash for the purchase.
+ */
+export function canAffordPurchase(playerCash: number, price: number): boolean {
+  return playerCash >= price
+}

--- a/tests/cityOwnership.test.ts
+++ b/tests/cityOwnership.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateBuyPrice,
+  calculateTakeoverPrice,
+  calculateProtectionTax,
+  calculateJazzPassiveIncome,
+  canAffordPurchase,
+  type OwnedCity
+} from '../src/game/cityOwnership'
+
+const smallCity: OwnedCity = {
+  cityId: 1,
+  populationTier: 'small',
+  isCoastal: false,
+  marketValue: 100,
+  ownerId: null
+}
+
+const majorCoastalCity: OwnedCity = {
+  cityId: 2,
+  populationTier: 'major',
+  isCoastal: true,
+  marketValue: 500,
+  ownerId: null
+}
+
+describe('calculateBuyPrice()', () => {
+  it('returns base price for neutral small city', () => {
+    const price = calculateBuyPrice(smallCity)
+    expect(price).toBeGreaterThan(0)
+  })
+
+  it('major cities cost more than small cities', () => {
+    expect(calculateBuyPrice(majorCoastalCity)).toBeGreaterThan(calculateBuyPrice(smallCity))
+  })
+})
+
+describe('calculateTakeoverPrice()', () => {
+  it('costs more than neutral buy price', () => {
+    const buy = calculateBuyPrice(smallCity)
+    const takeover = calculateTakeoverPrice(smallCity, 'bootlegger')
+    expect(takeover).toBeGreaterThan(buy)
+  })
+
+  it('applies Pharmacist +25% takeover cost', () => {
+    const base = calculateTakeoverPrice(smallCity, 'bootlegger')
+    const pharma = calculateTakeoverPrice(smallCity, 'pharmacist')
+    expect(pharma).toBeGreaterThanOrEqual(Math.floor(base * 1.25))
+    expect(pharma).toBeLessThanOrEqual(Math.ceil(base * 1.25))
+  })
+})
+
+describe('calculateProtectionTax()', () => {
+  it('returns positive income per city', () => {
+    const tax = calculateProtectionTax(smallCity, false)
+    expect(tax).toBeGreaterThan(0)
+  })
+
+  it('returns 50% penalty when in jail', () => {
+    const full = calculateProtectionTax(smallCity, false)
+    const jailed = calculateProtectionTax(smallCity, true)
+    expect(jailed).toBe(Math.floor(full * 0.5))
+  })
+
+  it('major city generates more tax than small city', () => {
+    expect(calculateProtectionTax(majorCoastalCity, false)).toBeGreaterThan(
+      calculateProtectionTax(smallCity, false)
+    )
+  })
+})
+
+describe('calculateJazzPassiveIncome()', () => {
+  it('returns positive income for jazz singer in major city', () => {
+    const income = calculateJazzPassiveIncome('jazz_singer', majorCoastalCity)
+    expect(income).toBeGreaterThan(0)
+  })
+
+  it('returns 0 for non-jazz characters', () => {
+    expect(calculateJazzPassiveIncome('bootlegger', majorCoastalCity)).toBe(0)
+  })
+
+  it('returns 0 for jazz singer in small city', () => {
+    expect(calculateJazzPassiveIncome('jazz_singer', smallCity)).toBe(0)
+  })
+})
+
+describe('canAffordPurchase()', () => {
+  it('returns true when cash >= price', () => {
+    expect(canAffordPurchase(500, 400)).toBe(true)
+  })
+
+  it('returns false when cash < price', () => {
+    expect(canAffordPurchase(200, 400)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
City purchase, hostile takeover, and Protection Tax passive income system.

## Changes
- `calculateBuyPrice()`: tier-based prices small→major
- `calculateTakeoverPrice()`: 1.5× premium + Pharmacist +25% cost modifier
- `calculateProtectionTax()`: 10% of market value, 50% while in jail
- `calculateJazzPassiveIncome()`: passive income in large/major cities
- `canAffordPurchase()`: cash check helper

## Testing
- [x] 12 tests, all 149 passing
- [x] TypeScript clean

Closes #14