### PR TITLE
feat(game): NPC scripted syndicate (#15)

### DIFF
--- a/src/game/npc.ts
+++ b/src/game/npc.ts
@@ -1,0 +1,60 @@
+import { getUpgradeCost } from './production'
+
+export type NpcAction = 'upgrade' | 'buy_city' | 'double_cross' | 'sell'
+
+export interface NpcState {
+  playerId: number
+  characterClass: string
+  cash: number
+  alcoholUnits: number
+  distilleryTier: number    // 1-5
+  stillCount: number        // 1-3
+  ownedCityIds: number[]
+  currentCityId: number
+  isInJail: boolean
+  heat: number              // 0-100
+  season: number            // current game season (1-indexed)
+}
+
+/** NPC action priority order, evaluated top-down each season */
+export const NPC_PRIORITY: NpcAction[] = ['upgrade', 'buy_city', 'double_cross', 'sell']
+
+const WEALTH_DECAY_RATE    = 0.3   // 30% cash lost every 4 seasons
+const WEALTH_DECAY_SEASONS = 4
+
+/**
+ * Apply NPC wealth decay every WEALTH_DECAY_SEASONS seasons.
+ * Season 0 is excluded (pre-game); decay fires on seasons 4, 8, 12, …
+ */
+export function applyWealthDecay(npc: NpcState): NpcState {
+  if (npc.season === 0 || npc.season % WEALTH_DECAY_SEASONS !== 0) return npc
+  return { ...npc, cash: Math.floor(npc.cash * (1 - WEALTH_DECAY_RATE)) }
+}
+
+/**
+ * Deterministic NPC action selection.
+ *
+ * Priority:
+ * 1. Upgrade distillery — if affordable and not at max tier
+ * 2. Buy nearest neutral city — if affordable and one is available
+ * 3. Double Cross — if an intercept opportunity exists
+ * 4. Sell — fallback (also forced when in jail)
+ *
+ * @param npc               - current NPC state
+ * @param canUpgrade        - true if there is an upgrade available (tier < 5) that NPC can afford
+ * @param neutralCityNearby - true if an unowned city is reachable and affordable
+ * @param interceptPossible - true if a rival player is on the NPC's movement path
+ */
+export function selectNpcAction(
+  npc: NpcState,
+  canUpgrade: boolean,
+  neutralCityNearby: boolean,
+  interceptPossible = false
+): NpcAction {
+  if (npc.isInJail) return 'sell'
+
+  if (canUpgrade && npc.distilleryTier < 5) return 'upgrade'
+  if (neutralCityNearby) return 'buy_city'
+  if (interceptPossible) return 'double_cross'
+  return 'sell'
+}

--- a/tests/npc.test.ts
+++ b/tests/npc.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NPC_PRIORITY,
+  applyWealthDecay,
+  selectNpcAction,
+  type NpcState,
+  type NpcAction
+} from '../src/game/npc'
+
+const baseNpc: NpcState = {
+  playerId: 99,
+  characterClass: 'gangster',
+  cash: 1000,
+  alcoholUnits: 5,
+  distilleryTier: 1,
+  stillCount: 1,
+  ownedCityIds: [],
+  currentCityId: 1,
+  isInJail: false,
+  heat: 20,
+  season: 1
+}
+
+describe('NPC_PRIORITY', () => {
+  it('defines the 4-step priority list in order', () => {
+    expect(NPC_PRIORITY).toEqual(['upgrade', 'buy_city', 'double_cross', 'sell'])
+  })
+})
+
+describe('applyWealthDecay()', () => {
+  it('reduces cash by 30% every 4 seasons', () => {
+    const decayed = applyWealthDecay({ ...baseNpc, season: 4 })
+    expect(decayed.cash).toBe(700) // 1000 * 0.7
+  })
+
+  it('does NOT decay on non-multiples of 4', () => {
+    const unchanged = applyWealthDecay({ ...baseNpc, season: 3 })
+    expect(unchanged.cash).toBe(1000)
+  })
+
+  it('does NOT decay on season 0 (edge case)', () => {
+    const unchanged = applyWealthDecay({ ...baseNpc, season: 0 })
+    expect(unchanged.cash).toBe(1000)
+  })
+})
+
+describe('selectNpcAction()', () => {
+  it('returns "upgrade" when can afford upgrade and tier < 5', () => {
+    const npc: NpcState = { ...baseNpc, cash: 5000, distilleryTier: 1 }
+    const action = selectNpcAction(npc, true, false)
+    expect(action).toBe('upgrade')
+  })
+
+  it('returns "buy_city" when cannot upgrade but neutral city is nearby and affordable', () => {
+    // low tier (already max), no upgrade available → buy
+    const npc: NpcState = { ...baseNpc, cash: 2000, distilleryTier: 5 }
+    const action = selectNpcAction(npc, false, true)
+    expect(action).toBe('buy_city')
+  })
+
+  it('returns "double_cross" when no upgrade/buy available but intercept possible', () => {
+    const npc: NpcState = { ...baseNpc, cash: 100, distilleryTier: 5 }
+    const action = selectNpcAction(npc, false, false, true)
+    expect(action).toBe('double_cross')
+  })
+
+  it('returns "sell" as fallback', () => {
+    const npc: NpcState = { ...baseNpc, cash: 0, distilleryTier: 5 }
+    const action = selectNpcAction(npc, false, false, false)
+    expect(action).toBe('sell')
+  })
+
+  it('returns "sell" when in jail', () => {
+    const npc: NpcState = { ...baseNpc, isInJail: true }
+    const action = selectNpcAction(npc, true, true, true)
+    expect(action).toBe('sell')
+  })
+})


### PR DESCRIPTION
## Description
Deterministic NPC Scripted Syndicate logic.

## Changes
- `NPC_PRIORITY`: upgrade → buy_city → double_cross → sell
- `selectNpcAction()`: deterministic priority selection, forced to sell when jailed
- `applyWealthDecay()`: -30% cash every 4 seasons to prevent NPC from winning

## Testing
- [x] 9 tests, all 158 passing
- [x] TypeScript clean

Closes #15