### PR TITLE
feat(game): turn engine & resolution pipeline (#16)

### DIFF
--- a/src/game/turnEngine.ts
+++ b/src/game/turnEngine.ts
@@ -1,0 +1,71 @@
+export const SEASONS_PER_YEAR = 4
+export const TOTAL_SEASONS    = 52   // 4 × 13 years (1920–1933)
+export const TURN_DURATION_MS = 24 * 60 * 60 * 1000  // 24 hours
+
+export type ResolutionStep =
+  | 'intercepts'
+  | 'police'
+  | 'market_refresh'
+  | 'npc_turns'
+  | 'season_increment'
+  | 'year_event'
+  | 'protection_tax'
+
+export type TurnAction =
+  | { type: 'move';         targetPath: number[] }
+  | { type: 'sell';         cityId: number; alcoholUnits: number }
+  | { type: 'buy';          cityId: number; alcoholUnits: number }
+  | { type: 'upgrade';      stillNumber: number }
+  | { type: 'buy_city';     cityId: number }
+  | { type: 'bribe_spot';   cityId: number }
+  | { type: 'bribe_long';   cityId: number }
+  | { type: 'double_cross'; targetPlayerId: number }
+  | { type: 'skip' }
+
+/**
+ * True if the given season number is the first of its year.
+ * Years start at seasons 1, 5, 9, … (1-indexed).
+ */
+export function isYearStart(season: number): boolean {
+  return season > 0 && (season - 1) % SEASONS_PER_YEAR === 0
+}
+
+/** True when the game has reached or passed its final season. */
+export function isGameOver(season: number): boolean {
+  return season >= TOTAL_SEASONS
+}
+
+/**
+ * Returns the index of the next player in the turn order, wrapping around.
+ */
+export function getNextPlayerIndex(currentIndex: number, playerCount: number): number {
+  return (currentIndex + 1) % playerCount
+}
+
+/**
+ * True when the turn window has expired (>24h since turnStartMs).
+ */
+export function isTurnExpired(turnStartMs: number, nowMs: number): boolean {
+  return nowMs - turnStartMs >= TURN_DURATION_MS
+}
+
+/**
+ * Return the ordered resolution pipeline steps for the current turn.
+ * If `isYearStartSeason` is true, a year_event step is inserted after season_increment.
+ */
+export function buildResolutionSteps(isYearStartSeason: boolean): ResolutionStep[] {
+  const steps: ResolutionStep[] = [
+    'intercepts',
+    'police',
+    'market_refresh',
+    'npc_turns',
+    'season_increment'
+  ]
+
+  if (isYearStartSeason) {
+    steps.push('year_event')
+  }
+
+  steps.push('protection_tax')
+  return steps
+}

--- a/src/routes/games.ts
+++ b/src/routes/games.ts
@@ -38,6 +38,37 @@ gamesRouter.post('/:id/start', async (c) => {
   return c.json({ success: true })
 })
 
+gamesRouter.post('/:id/turn', async (c) => {
+  const gameId  = c.req.param('id')
+  const userId  = c.get('userId')
+  const actions = await c.req.json<unknown[]>()
+
+  // Verify it's this player's turn
+  const playerRow = await c.env.PROHIBITIONDB.prepare(
+    `SELECT gp.id, gp.turn_order, g.current_turn_player_index, g.current_season, g.status, g.turn_started_at
+     FROM game_players gp
+     JOIN games g ON g.id = gp.game_id
+     WHERE gp.game_id = ? AND gp.user_id = ?`
+  ).bind(gameId, userId).first<{
+    id: number; turn_order: number; current_turn_player_index: number;
+    current_season: number; status: string; turn_started_at: number | null
+  }>()
+
+  if (!playerRow) return c.json({ success: false, message: 'Not in game' }, 403)
+  if (playerRow.status !== 'active') return c.json({ success: false, message: 'Game not active' }, 400)
+  if (playerRow.turn_order !== playerRow.current_turn_player_index) {
+    return c.json({ success: false, message: 'Not your turn' }, 400)
+  }
+
+  // Record turn actions in the turns table
+  await c.env.PROHIBITIONDB.prepare(
+    `INSERT INTO turns (game_id, player_id, season, actions_json, submitted_at)
+     VALUES (?, ?, ?, ?, unixepoch())`
+  ).bind(gameId, playerRow.id, playerRow.current_season, JSON.stringify(actions)).run()
+
+  return c.json({ success: true, message: 'Turn submitted — resolution pending' })
+})
+
 gamesRouter.get('/:id/market', async (c) => {
   const gameId = c.req.param('id')
   const { results: prices } = await c.env.PROHIBITIONDB.prepare(

--- a/tests/turnEngine.test.ts
+++ b/tests/turnEngine.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  TOTAL_SEASONS,
+  SEASONS_PER_YEAR,
+  isYearStart,
+  isGameOver,
+  getNextPlayerIndex,
+  isTurnExpired,
+  buildResolutionSteps
+} from '../src/game/turnEngine'
+
+describe('Season constants', () => {
+  it('defines 52 total seasons over 13 years', () => {
+    expect(TOTAL_SEASONS).toBe(52)
+    expect(SEASONS_PER_YEAR).toBe(4)
+    expect(TOTAL_SEASONS / SEASONS_PER_YEAR).toBe(13)
+  })
+})
+
+describe('isYearStart()', () => {
+  it('returns true for season 1 (first season of year 1)', () => {
+    expect(isYearStart(1)).toBe(true)
+  })
+
+  it('returns true for season 5 (first season of year 2)', () => {
+    expect(isYearStart(5)).toBe(true)
+  })
+
+  it('returns false for mid-year season', () => {
+    expect(isYearStart(2)).toBe(false)
+    expect(isYearStart(6)).toBe(false)
+  })
+})
+
+describe('isGameOver()', () => {
+  it('returns false before season 52', () => {
+    expect(isGameOver(51)).toBe(false)
+    expect(isGameOver(1)).toBe(false)
+  })
+
+  it('returns true at season 52', () => {
+    expect(isGameOver(52)).toBe(true)
+  })
+
+  it('returns true beyond season 52', () => {
+    expect(isGameOver(53)).toBe(true)
+  })
+})
+
+describe('getNextPlayerIndex()', () => {
+  it('increments to next player', () => {
+    expect(getNextPlayerIndex(0, 4)).toBe(1)
+    expect(getNextPlayerIndex(2, 4)).toBe(3)
+  })
+
+  it('wraps back to player 0 after last player', () => {
+    expect(getNextPlayerIndex(3, 4)).toBe(0)
+  })
+})
+
+describe('isTurnExpired()', () => {
+  const now = new Date('2025-01-10T12:00:00Z').getTime()
+
+  it('returns false when less than 24h have passed', () => {
+    const turnStart = new Date('2025-01-10T00:00:00Z').getTime()
+    expect(isTurnExpired(turnStart, now)).toBe(false)
+  })
+
+  it('returns true when more than 24h have passed', () => {
+    const turnStart = new Date('2025-01-09T11:59:00Z').getTime()
+    expect(isTurnExpired(turnStart, now)).toBe(true)
+  })
+})
+
+describe('buildResolutionSteps()', () => {
+  it('returns the ordered resolution pipeline', () => {
+    const steps = buildResolutionSteps(false)
+    expect(steps).toEqual([
+      'intercepts',
+      'police',
+      'market_refresh',
+      'npc_turns',
+      'season_increment',
+      'protection_tax'
+    ])
+  })
+
+  it('includes year_event when it is the start of a year', () => {
+    const steps = buildResolutionSteps(true)
+    expect(steps).toContain('year_event')
+    // year_event comes after season_increment
+    const seIdx = steps.indexOf('season_increment')
+    const yeIdx = steps.indexOf('year_event')
+    expect(yeIdx).toBeGreaterThan(seIdx)
+  })
+})


### PR DESCRIPTION
## Description
Sequential turn engine with 24h timer, resolution pipeline, and turn submission endpoint.

## Changes
- `TOTAL_SEASONS=52`, `TURN_DURATION_MS=24h` constants
- `isYearStart()`, `isGameOver()`, `getNextPlayerIndex()`, `isTurnExpired()`
- `buildResolutionSteps()`: full resolution order including optional year event
- `TurnAction` union type for all move/buy/sell/upgrade/bribe/double_cross/skip actions
- `POST /api/games/:id/turn` — turn ownership check, records actions to DB

## Testing
- [x] 13 tests, all 171 passing
- [x] TypeScript clean

Closes #16