### PR TITLE
feat(api): 3mails notification integration (#17)

### DIFF
--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,81 @@
+const GAME_START_YEAR = 1921
+const SEASONS_PER_YEAR = 4
+const SEASON_NAMES = ['Spring', 'Summer', 'Autumn', 'Winter'] as const
+
+export type NotificationEvent =
+  | 'turn_start'
+  | 'season_summary'
+  | 'double_cross_received'
+  | 'jail'
+  | 'game_end'
+
+export interface NotificationPayload {
+  eventType: NotificationEvent
+  gameId: string
+  playerId: number
+  seasonLabel: string
+  subject: string
+  details: Record<string, unknown>
+}
+
+/**
+ * Convert a 1-indexed season number to a human-readable label.
+ * Season 1 = Spring 1920, Season 52 = Winter 1933.
+ */
+export function getSeasonLabel(season: number): string {
+  const yearOffset  = Math.floor((season - 1) / SEASONS_PER_YEAR)
+  const seasonIndex = (season - 1) % SEASONS_PER_YEAR
+  return `${SEASON_NAMES[seasonIndex]} ${GAME_START_YEAR + yearOffset}`
+}
+
+const SUBJECT_TEMPLATES: Record<NotificationEvent, (label: string) => string> = {
+  turn_start:            (l) => `It's ${l} — Your turn, Boss`,
+  season_summary:        (l) => `${l} season resolved — check your empire`,
+  double_cross_received: (l) => `${l} — You've been robbed!`,
+  jail:                  (l) => `${l} — You're behind bars`,
+  game_end:              (l) => `${l} — Prohibition ends. Final tallies are in!`
+}
+
+/**
+ * Construct a notification payload for a given event.
+ */
+export function buildNotificationPayload(
+  eventType: NotificationEvent,
+  gameId: string,
+  playerId: number,
+  season: number,
+  details: Record<string, unknown> = {}
+): NotificationPayload {
+  const seasonLabel = getSeasonLabel(season)
+  return {
+    eventType,
+    gameId,
+    playerId,
+    seasonLabel,
+    subject:  SUBJECT_TEMPLATES[eventType](seasonLabel),
+    details
+  }
+}
+
+/**
+ * Send a notification to the 3mails endpoint.
+ * Failures are caught and logged — they must never block turn resolution.
+ */
+export async function sendNotification(
+  endpoint: string,
+  apiKey: string,
+  payload: NotificationPayload
+): Promise<void> {
+  try {
+    await fetch(endpoint, {
+      method:  'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key':    apiKey
+      },
+      body: JSON.stringify(payload)
+    })
+  } catch (err) {
+    console.error('[notifications] Failed to send notification:', err)
+  }
+}

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getSeasonLabel,
+  buildNotificationPayload,
+  sendNotification,
+  type NotificationEvent,
+  type NotificationPayload
+} from '../src/services/notifications'
+
+describe('getSeasonLabel()', () => {
+  it('returns Spring 1921 for season 1', () => {
+    expect(getSeasonLabel(1)).toBe('Spring 1921')
+  })
+
+  it('returns Summer 1921 for season 2', () => {
+    expect(getSeasonLabel(2)).toBe('Summer 1921')
+  })
+
+  it('returns Autumn 1921 for season 3', () => {
+    expect(getSeasonLabel(3)).toBe('Autumn 1921')
+  })
+
+  it('returns Winter 1921 for season 4', () => {
+    expect(getSeasonLabel(4)).toBe('Winter 1921')
+  })
+
+  it('returns Spring 1922 for season 5', () => {
+    expect(getSeasonLabel(5)).toBe('Spring 1922')
+  })
+
+  it('returns Winter 1933 for season 52', () => {
+    expect(getSeasonLabel(52)).toBe('Winter 1933')
+  })
+})
+
+describe('buildNotificationPayload()', () => {
+  it('builds a turn_start payload', () => {
+    const payload = buildNotificationPayload('turn_start', 'game-1', 42, 7)
+    expect(payload.eventType).toBe('turn_start')
+    expect(payload.gameId).toBe('game-1')
+    expect(payload.playerId).toBe(42)
+    expect(payload.seasonLabel).toBe('Autumn 1922')  // season 7
+    expect(payload.subject).toContain('Your turn')
+  })
+
+  it('builds a jail payload', () => {
+    const payload = buildNotificationPayload('jail', 'game-1', 42, 3, { seasons: 2 })
+    expect(payload.eventType).toBe('jail')
+    expect(payload.details).toMatchObject({ seasons: 2 })
+  })
+
+  it('builds a game_end payload', () => {
+    const payload = buildNotificationPayload('game_end', 'game-1', 42, 52)
+    expect(payload.eventType).toBe('game_end')
+    expect(payload.seasonLabel).toBe('Winter 1933')
+  })
+})
+
+describe('sendNotification()', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('POSTs payload to 3mails endpoint with API key header', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    const payload: NotificationPayload = {
+      eventType: 'turn_start',
+      gameId: 'g1',
+      playerId: 1,
+      seasonLabel: 'Spring 1920',
+      subject: 'Your turn',
+      details: {}
+    }
+
+    await sendNotification('https://3mails.example.com', 'key-123', payload)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://3mails.example.com',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'X-API-Key': 'key-123' })
+      })
+    )
+  })
+
+  it('does not throw when 3mails endpoint fails', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+
+    const payload: NotificationPayload = {
+      eventType: 'turn_start',
+      gameId: 'g1',
+      playerId: 1,
+      seasonLabel: 'Spring 1920',
+      subject: 'Your turn',
+      details: {}
+    }
+
+    // Should not throw
+    await expect(sendNotification('https://3mails.example.com', 'key', payload)).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Description
Player notifications via 3mails for all key game moments.

## Changes
- `getSeasonLabel()`: season 1→"Spring 1921", season 52→"Winter 1933"
- `buildNotificationPayload()`: typed payload with subject templates for each event type
- `sendNotification()`: POST to 3mails with `X-API-Key`, failures logged not thrown
- Events: turn_start, season_summary, double_cross_received, jail, game_end
- Secrets: endpoint URL + API key via Worker env (`.dev.vars`, never hardcoded)

## Testing
- [x] 11 tests, all 182 passing
- [x] TypeScript clean

Closes #17