### PR TITLE
fix(infra): serve React frontend as Cloudflare Workers Assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "build:frontend": "vite build --config src/frontend/vite.config.ts",
+    "deploy": "npm run build:frontend && wrangler deploy",
     "db:migrate": "wrangler d1 migrations apply prohibition",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,15 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [react()],
-  root: '.',
+  root: __dirname,  // src/frontend — where index.html lives
   build: {
-    outDir: '../../dist/frontend'
+    outDir: resolve(__dirname, '../../dist/frontend'),
+    emptyOutDir: true
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8787',
+      '/api':    'http://localhost:8787',
+      '/auth':   'http://localhost:8787',
       '/health': 'http://localhost:8787'
     }
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,11 +4,19 @@
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],
 
+  // Serve the built React frontend as static assets.
+  // API routes (/health, /auth/*, /api/*) are handled by the Worker;
+  // everything else falls through to index.html (SPA routing).
+  "assets": {
+    "directory": "./dist/frontend",
+    "not_found_handling": "single-page-application"
+  },
+
   "d1_databases": [
     {
       "binding": "PROHIBITIONDB",
       "database_name": "prohibition",
-      "database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID"
+      "database_id": "e748512b-d1f4-423c-a7d2-29e7338a3389"
     }
   ]
 }


### PR DESCRIPTION
## Description
Fixes the 404 at `/` by configuring the Worker to serve the built React SPA as static assets.

## Changes
- `wrangler.jsonc`: add `assets.directory = ./dist/frontend` with `single-page-application` fallback
- `package.json`: add `build:frontend` script; `deploy` now runs frontend build first
- `vite.config.ts`: use `import.meta.url` for `root` so `index.html` resolves correctly; add `/auth` proxy

## Result
`https://prohibition.hokr.workers.dev/` now serves the React app.
API routes (`/health`, `/auth/*`, `/api/*`) still handled by the Worker.