### PR TITLE
infra(db): add mission deck and player mission migrations (#43)

### DIFF
--- a/migrations/0024_mission_deck.sql
+++ b/migrations/0024_mission_deck.sql
@@ -1,0 +1,21 @@
+CREATE TABLE game_mission_deck (
+  id      INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id TEXT NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+  deck    TEXT NOT NULL DEFAULT '[]',
+  discard TEXT NOT NULL DEFAULT '[]',
+  UNIQUE(game_id)
+);
+
+CREATE TABLE player_missions (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id          TEXT NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+  player_id        INTEGER NOT NULL REFERENCES game_players(id) ON DELETE CASCADE,
+  card_id          INTEGER NOT NULL,
+  status           TEXT NOT NULL DEFAULT 'held',
+  progress         TEXT NOT NULL DEFAULT '{}',
+  assigned_season  INTEGER NOT NULL,
+  completed_season INTEGER,
+  reward_paid      INTEGER NOT NULL DEFAULT 0,
+  penalty_paid     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX idx_player_missions_game_player ON player_missions(game_id, player_id);

--- a/migrations/0025_mission_player_cols.sql
+++ b/migrations/0025_mission_player_cols.sql
@@ -1,0 +1,2 @@
+ALTER TABLE game_players ADD COLUMN total_cash_earned INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE game_players ADD COLUMN consecutive_clean_seasons INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Description
Two SQL migrations to support the Mission Cards system.

## Changes
- `0024_mission_deck.sql`: creates `game_mission_deck` (deck/discard JSON arrays, UNIQUE game_id) and `player_missions` tables with index
- `0025_mission_player_cols.sql`: adds `total_cash_earned` and `consecutive_clean_seasons` to `game_players`

## Testing
- [x] Validation passes (190 tests)

## Checklist
- [x] Architecture conventions respected
- [x] Tests pass locally

Closes #43