### PR TITLE
feat(frontend): MissionPanel component and GamePage wiring (#50)

### DIFF
--- a/src/frontend/src/components/CelebrationDialog.tsx
+++ b/src/frontend/src/components/CelebrationDialog.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useState } from 'react'
+import { getMissionCardDisplay } from '../data/missions'
+
+export interface Celebration {
+  type: 'claim_city' | 'upgrade_still' | 'upgrade_vehicle' | 'mission_complete'
+  cityId?: number
+  newTier?: number
+  vehicleId?: string
+  missionCardId?: number
+  reward?: number
+}
+
+const TIER_NAMES = ['', 'Basic Still', 'Copper Pot', 'Column Still', 'Industrial Press', 'Empire Distillery']
+
+const VEHICLE_NAMES: Record<string, string> = {
+  roadster:       'Roadster',
+  truck:          'Delivery Truck',
+  workhorse:      'Workhorse',
+  whiskey_runner: 'Whiskey Runner',
+}
+
+const SPARKLES = ['✦', '★', '✧', '✶', '✦', '★', '✧', '✶', '✦', '★', '✧', '✶']
+
+interface CelebrationDialogProps {
+  celebration: Celebration
+  cityName?: string
+  onClose: () => void
+}
+
+export default function CelebrationDialog({ celebration, cityName, onClose }: CelebrationDialogProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 50)
+    return () => clearTimeout(t)
+  }, [])
+
+  function handleClose() {
+    setVisible(false)
+    setTimeout(onClose, 250)
+  }
+
+  const citySlug = cityName?.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '') ?? ''
+
+  let headline = ''
+  let subtext = ''
+  let imageSrc = ''
+  let glowColor = 'rgba(251,191,36,0.45)'
+  let borderColor = 'border-amber-500'
+
+  if (celebration.type === 'claim_city') {
+    headline = 'City Claimed!'
+    subtext = cityName ? `${cityName} now flies your colors.` : 'A new city joins your empire.'
+    imageSrc = `/cities/${citySlug}.png`
+    glowColor = 'rgba(251,191,36,0.45)'
+    borderColor = 'border-amber-500'
+  } else if (celebration.type === 'upgrade_still') {
+    headline = 'Still Upgraded!'
+    const tierName = TIER_NAMES[celebration.newTier ?? 1]
+    subtext = cityName
+      ? `${cityName}'s operation is now a ${tierName}.`
+      : `Upgraded to a ${tierName}.`
+    imageSrc = `/cities/${citySlug}.png`
+    glowColor = 'rgba(34,197,94,0.4)'
+    borderColor = 'border-green-500'
+  } else if (celebration.type === 'upgrade_vehicle') {
+    headline = 'New Wheels!'
+    const vehicleName = VEHICLE_NAMES[celebration.vehicleId ?? ''] ?? celebration.vehicleId ?? ''
+    subtext = `You're now rolling in a ${vehicleName}.`
+    imageSrc = `/vehicles/${celebration.vehicleId}.png`
+    glowColor = 'rgba(59,130,246,0.4)'
+    borderColor = 'border-blue-500'
+  } else if (celebration.type === 'mission_complete') {
+    const missionCard = getMissionCardDisplay(celebration.missionCardId ?? 0)
+    headline = 'Mission Complete!'
+    subtext = missionCard
+      ? `"${missionCard.title}" — $${(celebration.reward ?? 0).toLocaleString()} collected.`
+      : `$${(celebration.reward ?? 0).toLocaleString()} reward collected.`
+    glowColor = 'rgba(168,85,247,0.4)'
+    borderColor = 'border-purple-500'
+  }
+
+  return (
+    <div
+      className={`fixed inset-0 z-[60] flex items-center justify-center transition-all duration-300 ${
+        visible ? 'bg-black/80' : 'bg-black/0'
+      }`}
+      onClick={handleClose}
+    >
+      {/* Floating sparkles */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        {SPARKLES.map((s, i) => (
+          <span
+            key={i}
+            className="absolute text-amber-400 animate-bounce select-none"
+            style={{
+              left:              `${(i * 8.3 + 3) % 92}%`,
+              top:               `${(i * 7.7 + 5) % 85}%`,
+              fontSize:          `${14 + (i % 3) * 6}px`,
+              animationDelay:    `${(i * 0.17) % 0.9}s`,
+              animationDuration: `${0.7 + (i * 0.11) % 0.6}s`,
+              opacity:           visible ? 0.8 : 0,
+              transition:        'opacity 0.4s',
+            }}
+          >
+            {s}
+          </span>
+        ))}
+      </div>
+
+      {/* Card */}
+      <div
+        className={`relative bg-stone-900 border-2 ${borderColor} rounded-2xl overflow-hidden w-80 transition-all duration-300 ${
+          visible ? 'scale-100 opacity-100' : 'scale-90 opacity-0'
+        }`}
+        style={{ boxShadow: `0 0 60px ${glowColor}, 0 0 120px ${glowColor.replace('0.4', '0.2').replace('0.45', '0.2')}` }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Image area */}
+        <div className="relative h-52 bg-stone-800 overflow-hidden">
+          {imageSrc && (
+            <img
+              src={imageSrc}
+              alt={headline}
+              className="absolute inset-0 w-full h-full object-cover"
+              style={{ filter: 'sepia(0.25) contrast(1.1) brightness(0.9)' }}
+              onError={e => { (e.target as HTMLImageElement).style.display = 'none' }}
+            />
+          )}
+          {/* Bottom gradient overlay */}
+          <div className="absolute inset-0 bg-gradient-to-t from-stone-900/90 via-stone-900/20 to-transparent" />
+
+          {/* Top badge */}
+          <div className="absolute top-3 inset-x-0 flex justify-center">
+            <span className="bg-black/60 backdrop-blur-sm text-amber-300 text-xs font-bold uppercase tracking-widest px-3 py-1 rounded-full border border-amber-500/50">
+              Achievement
+            </span>
+          </div>
+
+          {/* Headline */}
+          <div className="absolute bottom-0 inset-x-0 px-4 py-3">
+            <p className="text-amber-300 font-black text-2xl drop-shadow-lg leading-tight">{headline}</p>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 text-center">
+          <p className="text-stone-200 text-sm leading-relaxed">{subtext}</p>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 pb-5">
+          <button
+            onClick={handleClose}
+            className={`w-full py-2.5 font-black text-sm uppercase tracking-wider rounded-lg transition ${
+              celebration.type === 'upgrade_still'
+                ? 'bg-green-700 hover:bg-green-600 text-white shadow-[0_0_20px_rgba(34,197,94,0.4)]'
+                : celebration.type === 'upgrade_vehicle'
+                ? 'bg-blue-700 hover:bg-blue-600 text-white shadow-[0_0_20px_rgba(59,130,246,0.4)]'
+                : celebration.type === 'mission_complete'
+                ? 'bg-purple-700 hover:bg-purple-600 text-white shadow-[0_0_20px_rgba(168,85,247,0.4)]'
+                : 'bg-amber-600 hover:bg-amber-500 text-stone-900 shadow-[0_0_20px_rgba(217,119,6,0.5)]'
+            }`}
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/components/MissionPanel.tsx
+++ b/src/frontend/src/components/MissionPanel.tsx
@@ -1,0 +1,204 @@
+import React from 'react'
+import { getMissionCardDisplay, type MissionCardDisplay } from '../data/missions'
+
+interface HeldMission {
+  id: number
+  cardId: number
+  progress: Record<string, unknown>
+  assignedSeason: number
+}
+
+interface MissionPanelProps {
+  missions: HeldMission[]
+  onClose: () => void
+  onDrawCard: () => void
+  canDraw: boolean
+}
+
+const TIER_BADGE: Record<string, string> = {
+  easy:       'text-amber-400 border-amber-600 bg-amber-900/40',
+  medium:     'text-blue-400 border-blue-600 bg-blue-900/40',
+  hard:       'text-red-400 border-red-600 bg-red-900/40',
+  legendary:  'text-purple-400 border-purple-600 bg-purple-900/40',
+}
+
+const TIER_GLOW: Record<string, string> = {
+  easy:       'border-amber-700',
+  medium:     'border-blue-700',
+  hard:       'border-red-800',
+  legendary:  'border-purple-800',
+}
+
+function computeProgress(
+  card: MissionCardDisplay,
+  progressData: Record<string, unknown>
+): { current: number; target: number } | null {
+  const params = card.params as Record<string, number | string>
+  const target = Number(params.target ?? params.count ?? 0)
+
+  switch (card.objectiveType) {
+    case 'total_sold_units': {
+      const sold = (progressData.sold_units ?? {}) as Record<string, number>
+      const current = Object.values(sold).reduce((a, b) => a + b, 0)
+      return { current, target }
+    }
+    case 'sold_units_of_type': {
+      const sold = (progressData.sold_units ?? {}) as Record<string, number>
+      const current = sold[String(params.alcoholType)] ?? 0
+      return { current, target }
+    }
+    case 'officials_bribed':
+      return { current: Number(progressData.officials_bribed) || 0, target }
+    case 'cities_visited': {
+      const visited = (progressData.visited_city_ids ?? []) as number[]
+      return { current: visited.length, target }
+    }
+    case 'sabotages_completed':
+      return { current: Number(progressData.sabotages_completed) || 0, target }
+    default:
+      return null
+  }
+}
+
+function objectiveLabel(card: MissionCardDisplay): string {
+  const params = card.params as Record<string, number | string>
+  switch (card.objectiveType) {
+    case 'cash_gte':              return `Hold $${Number(params.target).toLocaleString()} cash`
+    case 'cities_owned_gte':      return `Own ${params.target} cities`
+    case 'vehicles_owned_gte':    return `Own ${params.target} vehicles`
+    case 'distillery_tier_gte':   return `Reach Tier-${params.target} distillery`
+    case 'total_cargo_units_gte': return `Carry ${params.target} cargo units`
+    case 'cargo_units_of_type_gte': return `Carry ${params.target} ${params.alcoholType} units`
+    case 'heat_at_most':          return `Heat ≤ ${params.target}`
+    case 'heat_at_least':         return `Heat ≥ ${params.target}`
+    case 'total_sold_units':      return `Sell ${params.target} total units`
+    case 'sold_units_of_type':    return `Sell ${params.target} ${params.alcoholType} units`
+    case 'total_cash_earned':     return `Earn $${Number(params.target).toLocaleString()} total`
+    case 'officials_bribed':      return `Bribe ${params.target} officials`
+    case 'cities_visited':        return `Visit ${params.target} cities`
+    case 'turns_without_arrest':  return `${params.count} clean seasons`
+    case 'sabotages_completed':   return `Sabotage ${params.target} rivals`
+    default:                      return card.objectiveType
+  }
+}
+
+export default function MissionPanel({ missions, onClose, onDrawCard, canDraw }: MissionPanelProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-end pointer-events-none">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 pointer-events-auto"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div className="relative h-full w-80 bg-stone-900 border-l border-stone-700 flex flex-col overflow-hidden pointer-events-auto shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-stone-700 flex-shrink-0">
+          <div>
+            <p className="text-xs text-stone-400 uppercase tracking-wider">Mission Cards</p>
+            <p className="text-sm text-stone-300 font-semibold">{missions.length}/3 held</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-stone-500 hover:text-stone-200 text-xl leading-none transition"
+            aria-label="Close missions panel"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Card list */}
+        <div className="flex-1 overflow-y-auto p-3 space-y-3">
+          {missions.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-stone-500 text-sm italic">No missions held.</p>
+              <p className="text-stone-600 text-xs mt-1">Draw a card to get started.</p>
+            </div>
+          ) : (
+            missions.map(m => {
+              const card = getMissionCardDisplay(m.cardId)
+              if (!card) return null
+              const prog = computeProgress(card, m.progress)
+              const fillPct = prog ? Math.min(100, Math.round((prog.current / prog.target) * 100)) : null
+              return (
+                <div key={m.id} className={`bg-stone-800 border rounded-lg overflow-hidden ${TIER_GLOW[card.tier]}`}>
+                  {/* Card header */}
+                  <div className="px-3 pt-3 pb-1 flex items-start gap-2">
+                    <span className={`text-xs font-bold uppercase tracking-wider border rounded px-1.5 py-0.5 flex-shrink-0 ${TIER_BADGE[card.tier]}`}>
+                      {card.tier}
+                    </span>
+                    <p className="text-stone-100 font-bold text-sm leading-tight">{card.title}</p>
+                  </div>
+
+                  {/* Flavor */}
+                  <div className="px-3 pb-1">
+                    <p className="text-stone-300 text-xs leading-relaxed">"{card.flavor}"</p>
+                  </div>
+
+                  {/* History note */}
+                  <div className="px-3 pb-2">
+                    <p className="text-stone-400 text-xs italic leading-relaxed">{card.historyNote}</p>
+                    <a
+                      href={card.wikiUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 hover:text-blue-400 text-xs transition"
+                    >
+                      Learn more →
+                    </a>
+                  </div>
+
+                  {/* Objective + progress */}
+                  <div className="px-3 pb-2 space-y-1.5">
+                    <p className="text-stone-400 text-xs uppercase tracking-wide">{objectiveLabel(card)}</p>
+                    {prog !== null && (
+                      <div>
+                        <div className="flex justify-between text-xs mb-0.5">
+                          <span className="text-stone-400">{prog.current} / {prog.target}</span>
+                          <span className="text-stone-500">{fillPct}%</span>
+                        </div>
+                        <div className="h-1.5 bg-stone-700 rounded-full overflow-hidden">
+                          <div
+                            className={`h-full rounded-full transition-all ${
+                              card.tier === 'easy' ? 'bg-amber-500' :
+                              card.tier === 'medium' ? 'bg-blue-500' :
+                              card.tier === 'hard' ? 'bg-red-500' : 'bg-purple-500'
+                            }`}
+                            style={{ width: `${fillPct}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Reward / penalty */}
+                  <div className="px-3 pb-3 flex items-center justify-between">
+                    <span className="text-green-400 font-bold text-sm">+${card.reward.toLocaleString()}</span>
+                    <span className="text-amber-600 text-xs">⚠ costs ${card.reward.toLocaleString()} if unfinished</span>
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+
+        {/* Draw card button */}
+        <div className="px-3 py-3 border-t border-stone-700 flex-shrink-0">
+          {canDraw ? (
+            <button
+              onClick={onDrawCard}
+              className="w-full py-2 bg-amber-700 hover:bg-amber-600 text-stone-100 font-bold rounded uppercase tracking-wide text-sm transition"
+            >
+              Draw Card
+            </button>
+          ) : missions.length >= 3 ? (
+            <p className="text-center text-stone-500 text-xs italic">Holding maximum missions (3/3)</p>
+          ) : (
+            <p className="text-center text-stone-500 text-xs italic">Take your turn to draw a card</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/GamePage.tsx
+++ b/src/frontend/src/pages/GamePage.tsx
@@ -6,6 +6,7 @@ import InventoryPanel from '../components/InventoryPanel'
 import MarketPanel    from '../components/MarketPanel'
 import SeasonTimeline from '../components/SeasonTimeline'
 import JailOverlay    from '../components/JailOverlay'
+import MissionPanel   from '../components/MissionPanel'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const GAME_START_YEAR   = 1921
@@ -38,6 +39,7 @@ interface FullState {
     currentCityId: number | null; homeCityId: number | null
     adjustmentCards: number
     inventory: Array<{ alcohol_type: string; quantity: number }>
+    missions: Array<{ id: number; cardId: number; progress: Record<string, unknown>; assignedSeason: number }>
   }
   players: PlayerInfo[]
 }
@@ -70,6 +72,7 @@ export default function GamePage() {
   const [moveMode,     setMoveMode]     = useState(false)
   const [movePath,     setMovePath]     = useState<number[]>([])
   const [diceRoll,     setDiceRoll]     = useState<number | null>(null)
+  const [missionsOpen, setMissionsOpen] = useState(false)
 
   const fetchAll = useCallback(async () => {
     if (!gameId) return
@@ -469,6 +472,17 @@ export default function GamePage() {
                   </button>
                   <hr className="border-stone-700" />
                   <button
+                    onClick={() => setMissionsOpen(true)}
+                    className="w-full py-2 border border-purple-700 hover:bg-purple-900/40 text-purple-400 font-bold rounded uppercase tracking-wide text-sm transition flex items-center justify-center gap-1"
+                  >
+                    Missions
+                    {(player?.missions?.length ?? 0) > 0 && (
+                      <span className="bg-purple-700 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center font-black">
+                        {player?.missions?.length}
+                      </span>
+                    )}
+                  </button>
+                  <button
                     onClick={() => submitTurn([{ type: 'skip' }])}
                     className="w-full py-2 text-stone-500 hover:text-stone-300 text-xs uppercase tracking-wide transition"
                   >
@@ -482,6 +496,21 @@ export default function GamePage() {
               {isInJail ? 'Serving time…' : `Waiting for ${currentPlayerName}`}
             </p>
           )}
+
+          {/* Missions button (always visible) */}
+          <div className="pt-2 border-t border-stone-700">
+            <button
+              onClick={() => setMissionsOpen(true)}
+              className="w-full py-1.5 border border-purple-800 hover:bg-purple-900/30 text-purple-500 rounded uppercase tracking-wide text-xs transition flex items-center justify-center gap-1"
+            >
+              View Missions
+              {(player?.missions?.length ?? 0) > 0 && (
+                <span className="bg-purple-700 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center font-black">
+                  {player?.missions?.length}
+                </span>
+              )}
+            </button>
+          </div>
 
           {/* Player list */}
           {fullState && (
@@ -500,6 +529,19 @@ export default function GamePage() {
           )}
         </div>
       </div>
+
+      {/* Mission Panel overlay */}
+      {missionsOpen && (
+        <MissionPanel
+          missions={player?.missions ?? []}
+          onClose={() => setMissionsOpen(false)}
+          onDrawCard={() => {
+            setMissionsOpen(false)
+            submitTurn([{ type: 'draw_mission' }])
+          }}
+          canDraw={isMyTurn && !isInJail && (player?.missions?.length ?? 0) < 3}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description
Implements the MissionPanel frontend component and wires it into GamePage, completing the Mission Cards feature's frontend layer.

## Changes
- **`MissionPanel.tsx`** — slide-in overlay panel showing held mission cards with tier badges, flavor, historyNote (italic stone-400), Wikipedia link, cumulative progress bars, and reward/penalty amounts; includes Draw Card button
- **`CelebrationDialog.tsx`** — added `mission_complete` celebration type with purple glow and tier-accurate display
- **`GamePage.tsx`** — added `missions` to `FullState.player` type, `missionsOpen` state, Missions HUD button with held card count badge, and `<MissionPanel>` overlay rendered conditionally

## Testing
- [x] Validation passes (212 tests, typecheck clean)

## Checklist
- [x] Architecture conventions respected
- [x] Shared types updated where needed
- [x] All tests pass locally

Closes #50