### PR TITLE
fix: update tests to match post-balance game logic (#71)

### DIFF
--- a/tests/characters.test.ts
+++ b/tests/characters.test.ts
@@ -5,7 +5,6 @@ import {
   applyHeatModifier,
   applyProductionModifier,
   applyMovementModifier,
-  applyDoublerossModifier,
   applyBribeDuration,
   applyUpgradeCostModifier,
   applyTakeoverCostModifier,
@@ -68,8 +67,8 @@ describe('Hillbilly modifiers', () => {
 })
 
 describe('Gangster modifiers', () => {
-  it('+15% double cross success rate', () => {
-    expect(applyDoublerossModifier('gangster', 0.5)).toBeCloseTo(0.65)
+  it('claims cities 25% cheaper (takeover cost modifier)', () => {
+    expect(applyTakeoverCostModifier('gangster', 1000)).toBeCloseTo(750)
   })
 })
 
@@ -101,14 +100,14 @@ describe('Bootlegger (Clyde) modifiers', () => {
 })
 
 describe('Socialite (Eleanor) modifiers', () => {
-  it('+15% sell price anywhere', () => {
-    expect(applySellPriceModifier('socialite', 100)).toBeCloseTo(115)
+  it('+25% sell price anywhere', () => {
+    expect(applySellPriceModifier('socialite', 100)).toBeCloseTo(125)
   })
 })
 
 describe('Union Leader (Big Mike) modifiers', () => {
-  it('+20% double cross in large city', () => {
-    expect(applyDoublerossModifier('union_leader', 0.5)).toBeCloseTo(0.7)
+  it('+20% production from all stills', () => {
+    expect(applyProductionModifier('union_leader', 100)).toBeCloseTo(120)
   })
 })
 

--- a/tests/doubleCross.test.ts
+++ b/tests/doubleCross.test.ts
@@ -18,19 +18,19 @@ describe('calculateSuccessRate()', () => {
     expect(calculateSuccessRate('bootlegger', 'small')).toBeCloseTo(0.5)
   })
 
-  it('Gangster gets +15% bonus', () => {
+  it('Gangster gets same rate as any other class (bonus removed)', () => {
     const base = calculateSuccessRate('bootlegger', 'small')
     const gangster = calculateSuccessRate('gangster', 'small')
-    expect(gangster).toBeCloseTo(base + 0.15)
+    expect(gangster).toBeCloseTo(base)
   })
 
-  it('Union Leader gets +20% bonus in large/major city', () => {
+  it('Union Leader gets same rate in large city (bonus removed)', () => {
     const base = calculateSuccessRate('bootlegger', 'large')
     const ul = calculateSuccessRate('union_leader', 'large')
-    expect(ul).toBeCloseTo(base + 0.2)
+    expect(ul).toBeCloseTo(base)
   })
 
-  it('Union Leader bonus does NOT apply in small city', () => {
+  it('Union Leader rate is same in small city', () => {
     const base = calculateSuccessRate('bootlegger', 'small')
     const ul = calculateSuccessRate('union_leader', 'small')
     expect(ul).toBeCloseTo(base)
@@ -65,11 +65,10 @@ describe('resolveDoubleCross()', () => {
     expect(result.heatDelta).toBe(20)  // failure heat penalty
   })
 
-  it('Jazz Singer victim loses more cash on failure', () => {
+  it('Jazz Singer victim loses same cash as any other class (no special multiplier)', () => {
     const jazzTarget = { ...neutralTarget, characterClass: 'jazz_singer' }
     const normalResult = resolveDoubleCross('bootlegger', neutralTarget, true)
     const jazzResult = resolveDoubleCross('bootlegger', jazzTarget, true)
-    // Jazz Singer loses more cash (cashLossOnRobMultiplier: 1.35)
-    expect(Math.abs(jazzResult.victimCashLoss)).toBeGreaterThan(Math.abs(normalResult.victimCashLoss))
+    expect(Math.abs(jazzResult.victimCashLoss)).toBe(Math.abs(normalResult.victimCashLoss))
   })
 })

--- a/tests/gameService.test.ts
+++ b/tests/gameService.test.ts
@@ -65,7 +65,7 @@ describe('GameService.joinGame()', () => {
   })
 
   it('returns error when game is full (5 players)', async () => {
-    const db = makeDb({ firstResult: { id: 'g1', status: 'lobby', player_count: 5 } })
+    const db = makeDb({ firstResult: { id: 'g1', status: 'lobby', player_count: 5, max_players: 5 } })
     const svc = new GameService({ ...BASE_ENV, PROHIBITIONDB: db as any })
     const result = await svc.joinGame('code123', 99)
     expect(result.success).toBe(false)

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import app from '../src/index'
+import worker from '../src/index'
+
+// index.ts exports a Worker shape { fetch, scheduled }, not a bare Hono app.
+// Use worker.fetch() with a real Request to test routes.
+const mockEnv = {
+  PROHIBITIONDB: null as any,
+  ENCRYPTION_KEY: '',
+  MAILS_API_KEY: '',
+  MAILS_ENDPOINT: '',
+  THREEMAILS_API_KEY: '',
+  VAPID_PUBLIC_KEY: '',
+  VAPID_PRIVATE_KEY: '',
+  VAPID_SUBJECT: '',
+  ASSETS: { fetch: async () => new Response('', { status: 404 }) },
+} as any
 
 describe('health check', () => {
   it('GET /health returns ok', async () => {
-    const res = await app.request('/health')
+    const res = await worker.fetch(new Request('http://localhost/health'), mockEnv, {} as any)
     expect(res.status).toBe(200)
     const body = await res.json() as { ok: boolean; service: string }
     expect(body.ok).toBe(true)

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -68,8 +68,8 @@ describe('applySellModifier()', () => {
     expect(applySellModifier(100, 'bootlegger', 'bourbon')).toBe(100)
   })
 
-  it('applies Socialite +15% sell bonus', () => {
-    expect(applySellModifier(100, 'socialite', 'bourbon')).toBeCloseTo(115)
+  it('applies Socialite +25% sell bonus', () => {
+    expect(applySellModifier(100, 'socialite', 'bourbon')).toBeCloseTo(125)
   })
 
   it('applies Pharmacist 1.5× for medicinal spirits (moonshine)', () => {

--- a/tests/missions.test.ts
+++ b/tests/missions.test.ts
@@ -27,31 +27,31 @@ describe('MISSION_CARDS', () => {
     expect(counts.legendary).toBe(13)
   })
 
-  it('easy rewards are 500–1500', () => {
+  it('easy rewards are 100–275', () => {
     for (const card of MISSION_CARDS.filter(c => c.tier === 'easy')) {
-      expect(card.reward).toBeGreaterThanOrEqual(500)
-      expect(card.reward).toBeLessThanOrEqual(1500)
+      expect(card.reward).toBeGreaterThanOrEqual(100)
+      expect(card.reward).toBeLessThanOrEqual(275)
     }
   })
 
-  it('medium rewards are 2000–4000', () => {
+  it('medium rewards are 425–850', () => {
     for (const card of MISSION_CARDS.filter(c => c.tier === 'medium')) {
-      expect(card.reward).toBeGreaterThanOrEqual(2000)
-      expect(card.reward).toBeLessThanOrEqual(4000)
+      expect(card.reward).toBeGreaterThanOrEqual(425)
+      expect(card.reward).toBeLessThanOrEqual(850)
     }
   })
 
-  it('hard rewards are 5000–8000', () => {
+  it('hard rewards are 1050–1750', () => {
     for (const card of MISSION_CARDS.filter(c => c.tier === 'hard')) {
-      expect(card.reward).toBeGreaterThanOrEqual(5000)
-      expect(card.reward).toBeLessThanOrEqual(8000)
+      expect(card.reward).toBeGreaterThanOrEqual(1050)
+      expect(card.reward).toBeLessThanOrEqual(1750)
     }
   })
 
-  it('legendary rewards are 10000–15000', () => {
+  it('legendary rewards are 2100–3150', () => {
     for (const card of MISSION_CARDS.filter(c => c.tier === 'legendary')) {
-      expect(card.reward).toBeGreaterThanOrEqual(10000)
-      expect(card.reward).toBeLessThanOrEqual(15000)
+      expect(card.reward).toBeGreaterThanOrEqual(2100)
+      expect(card.reward).toBeLessThanOrEqual(3150)
     }
   })
 
@@ -139,12 +139,12 @@ describe('checkAndCompleteMissions()', () => {
   })
 
   it('completes a cash_gte mission when cash meets target', async () => {
-    // Card 1: cash_gte 500, reward 500
+    // Card 1: cash_gte target 500, reward 100
     const db = makeDb([{ id: 10, card_id: 1, progress: '{}' }]) as unknown as D1Database
     const snap: MissionSnapshot = { ...baseSnapshot, cash: 600 }
     const result = await checkAndCompleteMissions(db, 'game1', 1, 1, snap)
     expect(result.completedCardIds).toContain(1)
-    expect(result.totalReward).toBe(500)
+    expect(result.totalReward).toBe(100)
   })
 
   it('does not complete cash_gte mission when cash below target', async () => {


### PR DESCRIPTION
## Description
15 pre-existing test failures on release/v1.1 caused by character balance and game logic changes (commit c90fe40) that updated production code without updating test expectations.

## Changes
- `health.test.ts` — use `worker.fetch()` since `index.ts` exports Worker shape `{ fetch, scheduled }`, not a bare Hono app
- `characters.test.ts` — remove non-existent `applyDoublerossModifier` import; update Gangster (−25% takeover cost), Socialite (+25% sell), Union Leader (+20% production)
- `doubleCross.test.ts` — `calculateSuccessRate()` now returns flat 0.5 for all classes; Jazz Singer no longer has a cash-loss multiplier
- `market.test.ts` — Socialite sell bonus is +25% (was +15%)
- `missions.test.ts` — reward ranges match actual values; cash_gte reward is 100 not 500
- `gameService.test.ts` — full-game mock includes `max_players: 5`

## Testing
- [x] All 212 tests pass
- [x] Typecheck passes

## Checklist
- [x] Architecture conventions respected
- [x] Tests-only change — no production code modified
- [x] All tests pass locally

Closes #71