### PR TITLE
fix(chat): allow sending drinks outside your turn (#63)

### DIFF
--- a/src/frontend/src/components/ChatPanel.tsx
+++ b/src/frontend/src/components/ChatPanel.tsx
@@ -174,7 +174,7 @@ export default function ChatPanel({ gameId, myTurnOrder, players, playerColors, 
 
   const availableDrinks = inventoryItems.filter(i => i.quantity > 0)
   const otherPlayers = players.filter(p => !p.isYou)
-  const canSendDrink = isMyTurn && availableDrinks.length > 0
+  const canSendDrink = availableDrinks.length > 0
 
   const inputBar = (
     <div className="border-t border-stone-700 flex-shrink-0">
@@ -198,7 +198,7 @@ export default function ChatPanel({ gameId, myTurnOrder, players, playerColors, 
         <button
           onClick={() => canSendDrink && setDrinkOpen(o => !o)}
           disabled={!canSendDrink}
-          title={!isMyTurn ? 'Not your turn' : availableDrinks.length === 0 ? 'No drinks in inventory' : 'Send a drink'}
+          title={availableDrinks.length === 0 ? 'No drinks in inventory' : 'Send a drink'}
           className="px-2 py-1 bg-stone-700 hover:bg-stone-600 disabled:opacity-30 text-base rounded transition flex-shrink-0"
         >
           🥃


### PR DESCRIPTION
## Description
Remove the `isMyTurn` gate from `canSendDrink`. Sending a drink is a social action that doesn't consume a game action slot, so it should be available any time the player has inventory regardless of whose turn it is.

## Changes
- `src/frontend/src/components/ChatPanel.tsx` — `canSendDrink = availableDrinks.length > 0` (removed `isMyTurn &&`); updated tooltip

## Testing
- [x] Validation passes (212/212 tests, clean typecheck)

## Checklist
- [x] Architecture conventions respected
- [x] All tests pass locally

Closes #63