### PR TITLE
fix(test): fix flaky selectCities test (#74)

### DIFF
--- a/tests/gameService.test.ts
+++ b/tests/gameService.test.ts
@@ -99,13 +99,13 @@ describe('GameService.startGame()', () => {
 })
 
 describe('GameService.selectCities()', () => {
-  it('selects between 15 and 20 cities from the pool', () => {
+  it('selects between 12 and 20 cities from the pool', () => {
     const pool = Array.from({ length: 50 }, (_, i) => ({
       id: i + 1, region: ['Midwest', 'East Coast', 'South', 'West Coast', 'West'][i % 5]
     }))
     const svc = new GameService({ ...BASE_ENV, PROHIBITIONDB: {} as any })
     const selected = svc.selectCities(pool as any)
-    expect(selected.length).toBeGreaterThanOrEqual(15)
+    expect(selected.length).toBeGreaterThanOrEqual(12)
     expect(selected.length).toBeLessThanOrEqual(20)
   })
 


### PR DESCRIPTION
## Description
Fixes the intermittently failing `selectCities` test (issue #74).

## Root cause
The test asserted `selected.length >= 15` but `MIN_CITIES = 12`. When `Math.random()` produced a target of 12–14, the algorithm correctly stopped there but the test failed.

## Changes
- `tests/gameService.test.ts` — corrected lower bound from 15 → 12 and updated test name to match

## Testing
- [x] Test passes on 5 consecutive runs
- [x] All 212 tests pass (`npm test`)
- [x] Type check passes (`npm run typecheck`)

## Checklist
- [x] Architecture conventions respected
- [x] No production code changed
- [x] All tests pass

Closes #74