### PR TITLE
feat(frontend): maximize button to restore full-screen Prohibition Times (#92)

### DIFF
--- a/src/frontend/src/components/ProhibitionTimes.tsx
+++ b/src/frontend/src/components/ProhibitionTimes.tsx
@@ -12,6 +12,7 @@ interface ProhibitionTimesProps {
   currentSeason: number
   onClose?: () => void
   isOverlay?: boolean
+  onMaximize?: () => void
 }
 
 // Deterministic shuffle seeded by season so the page stays stable during a turn
@@ -46,7 +47,7 @@ const TYPE_LABEL: Record<string, string> = {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function ProhibitionTimes({ gameId, currentSeason, onClose, isOverlay }: ProhibitionTimesProps) {
+export default function ProhibitionTimes({ gameId, currentSeason, onClose, isOverlay, onMaximize }: ProhibitionTimesProps) {
   const [systemMessages, setSystemMessages] = useState<GameMessage[]>([])
   const hasFetched = useRef(false)
   const [storyIndex, setStoryIndex] = useState(0)
@@ -131,6 +132,13 @@ export default function ProhibitionTimes({ gameId, currentSeason, onClose, isOve
             className="absolute top-3 right-4 text-stone-600 hover:text-stone-900 text-xl font-bold leading-none cursor-pointer"
             aria-label="Close newspaper"
           >✕</button>
+        )}
+        {isOverlay && onMaximize && (
+          <button
+            onClick={onMaximize}
+            className="absolute top-3 left-4 text-stone-600 hover:text-stone-900 text-xl font-bold leading-none cursor-pointer"
+            aria-label="Maximize newspaper"
+          >⛶</button>
         )}
         <p className="text-xs tracking-[0.3em] uppercase text-stone-600 font-serif border-b border-stone-700 mb-1 pb-1">
           Est. 1920 · Chicago, Ill.

--- a/src/frontend/src/pages/GamePage.tsx
+++ b/src/frontend/src/pages/GamePage.tsx
@@ -2490,6 +2490,7 @@ export default function GamePage() {
           currentSeason={game?.currentSeason ?? 1}
           isOverlay
           onClose={() => setShowPaper(false)}
+          onMaximize={!serverIsMyTurn ? () => { setNewsDeclined(false); setShowPaper(false) } : undefined}
         />
       )}
       {/* Mission Panel overlay */}

--- a/tests/prohibitionTimes.test.ts
+++ b/tests/prohibitionTimes.test.ts
@@ -181,3 +181,24 @@ describe('ProhibitionTimes close button visibility condition', () => {
     expect(shouldShowClose(true, () => {})).toBe(true)
   })
 })
+
+describe('ProhibitionTimes maximize button visibility condition', () => {
+  const shouldShowMaximize = (isOverlay: boolean, onMaximize: (() => void) | undefined) =>
+    isOverlay && !!onMaximize
+
+  it('shows maximize button when isOverlay and onMaximize are both provided', () => {
+    expect(shouldShowMaximize(true, () => {})).toBe(true)
+  })
+
+  it('hides maximize button when not in overlay mode', () => {
+    expect(shouldShowMaximize(false, () => {})).toBe(false)
+  })
+
+  it('hides maximize button when onMaximize is not provided (active turn)', () => {
+    expect(shouldShowMaximize(true, undefined)).toBe(false)
+  })
+
+  it('hides maximize button when neither isOverlay nor onMaximize provided', () => {
+    expect(shouldShowMaximize(false, undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
Adds a ⛶ maximize button in the top-left of the overlay masthead. When a player dismisses the full-screen newspaper (✕) and later opens it via the sidebar button, they can click ⛶ to restore the full-screen blocking view — but only while still waiting for their turn. During an active turn the button is absent.

## Changes
- `ProhibitionTimes.tsx` — new `onMaximize?` prop; renders ⛶ button when `isOverlay && onMaximize`
- `GamePage.tsx` — passes `onMaximize={!serverIsMyTurn ? () => { setNewsDeclined(false); setShowPaper(false) } : undefined}` to the overlay
- `tests/prohibitionTimes.test.ts` — 4 new unit tests for maximize button visibility condition

## Testing
- [x] `npm run typecheck` — clean
- [x] `npm test` — 244/244 passing
- [ ] Visual QA: ⛶ button visible in overlay during waiting turn; absent during active turn; clicking restores full-screen

## Checklist
- [x] Architecture conventions respected
- [x] No new state needed — reuses existing `newsDeclined` / `serverIsMyTurn`
- [x] Tests added
- [x] All tests pass locally

Closes #92