### PR TITLE
feat(db): snitch mechanic schema migrations (#100)

### DIFF
--- a/migrations/0038_snitch_role.sql
+++ b/migrations/0038_snitch_role.sql
@@ -1,0 +1,5 @@
+-- Snitch mechanic: player role, jail history, federal bribe tracking, pending sightings
+ALTER TABLE game_players ADD COLUMN role TEXT NOT NULL DEFAULT 'bootlegger';
+ALTER TABLE game_players ADD COLUMN jailed_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE game_players ADD COLUMN federal_bribe_expires_season INTEGER;
+ALTER TABLE game_players ADD COLUMN pending_sightings TEXT;

--- a/migrations/0039_informants.sql
+++ b/migrations/0039_informants.sql
@@ -1,0 +1,10 @@
+-- Snitch mechanic: informants placed by snitches in cities to detect player movements
+CREATE TABLE informants (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id    INTEGER NOT NULL,
+  snitch_id  INTEGER NOT NULL,
+  city_id    INTEGER,
+  placed_at  INTEGER,
+  FOREIGN KEY (game_id)   REFERENCES games(id),
+  FOREIGN KEY (snitch_id) REFERENCES game_players(id)
+);

--- a/migrations/0040_snitch_accusations.sql
+++ b/migrations/0040_snitch_accusations.sql
@@ -1,0 +1,11 @@
+-- Snitch mechanic: accusations filed by snitches against specific players
+CREATE TABLE snitch_accusations (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id    INTEGER NOT NULL,
+  snitch_id  INTEGER NOT NULL,
+  target_id  INTEGER NOT NULL,
+  season     INTEGER NOT NULL,
+  success    INTEGER,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (game_id) REFERENCES games(id)
+);

--- a/migrations/0041_finger_attempts.sql
+++ b/migrations/0041_finger_attempts.sql
@@ -1,0 +1,11 @@
+-- Snitch mechanic: finger attempts by bootleggers trying to expose snitches
+CREATE TABLE finger_attempts (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  game_id     INTEGER NOT NULL,
+  accuser_id  INTEGER NOT NULL,
+  target_id   INTEGER NOT NULL,
+  season      INTEGER NOT NULL,
+  correct     INTEGER NOT NULL,
+  created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (game_id) REFERENCES games(id)
+);


### PR DESCRIPTION
## Description
Adds all DB schema required for the Snitch Mechanic feature (#99).

## Changes
- `0038_snitch_role.sql` — adds `role`, `jailed_count`, `federal_bribe_expires_season`, `pending_sightings` to `game_players`
- `0039_informants.sql` — new `informants` table for snitch city watchers
- `0040_snitch_accusations.sql` — new `snitch_accusations` table
- `0041_finger_attempts.sql` — new `finger_attempts` table for escalating finger costs

## Testing
- [x] Validation passes (248 tests, typecheck clean)

## Checklist
- [x] Architecture conventions respected (migration-per-change pattern)
- [x] No application code changes — schema only
- [x] All tests pass locally

Closes #100