### PR TITLE
feat(game): fed stop trigger, recruitment, and snitch role (#101)

### DIFF
--- a/src/frontend/src/components/FedStopDialog.tsx
+++ b/src/frontend/src/components/FedStopDialog.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react'
+
+interface FedStopDialogProps {
+  fineCost: number
+  jailSeasons: number
+  cargoUnits: number
+  cash: number
+  onPay: () => void
+  onJail: () => void
+  onSnitch: () => void
+}
+
+export default function FedStopDialog({ fineCost, jailSeasons, cargoUnits, cash, onPay, onJail, onSnitch }: FedStopDialogProps) {
+  const [confirmSnitch, setConfirmSnitch] = useState(false)
+  const actualFine = Math.min(fineCost, cash)
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/80" />
+
+      <div className="relative bg-stone-900 border border-indigo-900 rounded-lg shadow-2xl w-96 flex flex-col">
+        {/* Header */}
+        <div className="px-4 py-3 border-b border-indigo-900/60 bg-indigo-950/30 rounded-t-lg">
+          <p className="text-xs text-indigo-400 uppercase tracking-wider">Federal Stop</p>
+          <p className="text-indigo-200 font-bold text-lg">🕵️ Prohibition Bureau</p>
+          <p className="text-xs text-indigo-400/70">Bureau of Industrial Alcohol</p>
+        </div>
+
+        {/* Body */}
+        <div className="px-4 py-3 space-y-3">
+          <p className="text-stone-300 text-sm">
+            Federal agents have stopped your operation.
+            {cargoUnits > 0 && (
+              <span className="text-amber-400"> You're carrying {cargoUnits} unit{cargoUnits !== 1 ? 's' : ''} of contraband.</span>
+            )}
+          </p>
+
+          {/* Pay the fine */}
+          <button
+            onClick={onPay}
+            className="w-full text-left px-3 py-2.5 rounded border border-stone-600 bg-stone-800 hover:bg-stone-700 transition"
+          >
+            <p className="font-bold text-stone-200 text-sm">
+              💵 Pay the Fine — ${actualFine.toLocaleString()}
+            </p>
+            <p className="text-xs text-stone-400 mt-0.5">
+              {cash < fineCost
+                ? `You can only cover $${actualFine.toLocaleString()} of the $${fineCost.toLocaleString()} fine. Heat −5.`
+                : `25% of your cash. Walk away. Heat −5.`}
+            </p>
+          </button>
+
+          {/* Go to jail */}
+          <button
+            onClick={onJail}
+            className="w-full text-left px-3 py-2.5 rounded border border-stone-600 bg-stone-800 hover:bg-stone-700 transition"
+          >
+            <p className="font-bold text-stone-200 text-sm">
+              ⛓️ Go to Jail — {jailSeasons} season{jailSeasons !== 1 ? 's' : ''}
+            </p>
+            <p className="text-xs text-stone-400 mt-0.5">
+              Cooperate fully. Heat −10.{cargoUnits > 0 ? ' Your cargo remains.' : ''}
+            </p>
+          </button>
+
+          {/* Become a snitch */}
+          {!confirmSnitch ? (
+            <button
+              onClick={() => setConfirmSnitch(true)}
+              className="w-full text-left px-3 py-2.5 rounded border border-zinc-600 bg-zinc-800/50 hover:bg-zinc-700/50 transition"
+            >
+              <p className="font-bold text-zinc-300 text-sm">🤫 Become an Informant</p>
+              <p className="text-xs text-zinc-500 mt-0.5">Work for the feds. A different path.</p>
+            </button>
+          ) : (
+            <div className="rounded border border-red-900/60 bg-red-950/30 px-3 py-2.5 space-y-2">
+              <p className="text-xs text-red-300 font-bold">Are you sure?</p>
+              <p className="text-xs text-red-400/80">
+                You will <strong>never win as a bootlegger again</strong>. Your only path to victory is working for the feds — placing informants, building intel, and bringing down the leader.
+              </p>
+              <div className="flex gap-2 mt-1">
+                <button
+                  onClick={onSnitch}
+                  className="flex-1 py-1.5 bg-red-900 hover:bg-red-800 text-red-200 text-xs font-bold rounded transition"
+                >
+                  Yes — I'm in
+                </button>
+                <button
+                  onClick={() => setConfirmSnitch(false)}
+                  className="flex-1 py-1.5 bg-stone-700 hover:bg-stone-600 text-stone-300 text-xs rounded transition"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/GamePage.tsx
+++ b/src/frontend/src/pages/GamePage.tsx
@@ -7,6 +7,7 @@ import MarketDialog   from '../components/MarketDialog'
 import VehicleDialog  from '../components/VehicleDialog'
 import StillDialog    from '../components/StillDialog'
 import PoliceDialog   from '../components/PoliceDialog'
+import FedStopDialog  from '../components/FedStopDialog'
 import BribeDialog      from '../components/BribeDialog'
 import SeasonTimeline   from '../components/SeasonTimeline'
 import JailOverlay      from '../components/JailOverlay'
@@ -342,6 +343,7 @@ export default function GamePage() {
   const [trapOpen,     setTrapOpen]     = useState(false)
   const [viewCityId,   setViewCityId]   = useState<number | null>(null)
   const [policeEncounter, setPoliceEncounter] = useState<{ bribeCost: number; populationTier: string; heat: number } | null>(null)
+  const [fedEncounter, setFedEncounter] = useState<{ fineCost: number; jailSeasons: number; cargoUnits: number } | null>(null)
   const [leftOpen,  setLeftOpen]  = useState(true)
   const [rightOpen, setRightOpen] = useState(true)
   const [inviteEmail, setInviteEmail] = useState('')
@@ -935,6 +937,9 @@ export default function GamePage() {
         throw new Error(`Turn failed (${res.status}): ${text}`)
       }
       const data = await res.json()
+      if (data.fedEncounter) {
+        setFedEncounter(data.fedEncounter)
+      }
       if (data.policeEncounter) {
         setPoliceEncounter(data.policeEncounter)
       }
@@ -1724,6 +1729,19 @@ export default function GamePage() {
               setCelebrationQueue(prev => prev.slice(1))
               await fetchAll()
             }}
+          />
+        )}
+
+        {/* Federal stop dialog */}
+        {fedEncounter && (
+          <FedStopDialog
+            fineCost={fedEncounter.fineCost}
+            jailSeasons={fedEncounter.jailSeasons}
+            cargoUnits={fedEncounter.cargoUnits}
+            cash={player?.cash ?? 0}
+            onPay={() => { submitTurn([{ type: 'fed_stop_respond', choice: 'pay' }], { transition: true }); setFedEncounter(null) }}
+            onJail={() => { submitTurn([{ type: 'fed_stop_respond', choice: 'jail' }], { transition: true }); setFedEncounter(null) }}
+            onSnitch={() => { submitTurn([{ type: 'fed_stop_respond', choice: 'snitch' }], { transition: true }); setFedEncounter(null) }}
           />
         )}
 

--- a/src/game/police.ts
+++ b/src/game/police.ts
@@ -49,7 +49,7 @@ export const HEAT_CHANGES = {
 export const TIER_PASSIVE_HEAT: Record<number, number> = { 1: 0, 2: 1, 3: 1, 4: 2, 5: 4 }
 
 /** Bribe multiplier by city size */
-const TIER_BRIBE_MULTIPLIER: Record<PopulationTier, number> = {
+export const TIER_BRIBE_MULTIPLIER: Record<PopulationTier, number> = {
   small:  1.0,
   medium: 1.5,
   large:  2.5,
@@ -143,4 +143,42 @@ export function calculateSpotBribeCost(currentHeat: number, tier: PopulationTier
 export function calculateLongTermBribeCost(tier: PopulationTier): number {
   const base = 500
   return Math.floor(base * TIER_BRIBE_MULTIPLIER[tier])
+}
+
+// ── Federal Stop ─────────────────────────────────────────────────────────────
+
+export interface FedStopContext {
+  cityCount: number
+  cash: number
+  jailedCount: number
+  rankByWealth: number   // 1 = first place, N = last place
+  playerCount: number
+  federalBribeActive: boolean
+  cityBribed: boolean
+}
+
+/**
+ * Weighted probability roll for a Federal Stop.
+ * Base 3%; modifiers for desperation factors; floor 0.5%.
+ * Feds are NOT heat-based — they target struggling players more heavily.
+ */
+export function rollFedStop(ctx: FedStopContext): boolean {
+  let weight = 0.03
+  if (ctx.cityCount === 0)                      weight += 0.03  // lost home city
+  if (ctx.cash < 500)                           weight += 0.03  // desperate
+  if (ctx.jailedCount > 0)                      weight += 0.02  // prior record
+  if (ctx.rankByWealth === ctx.playerCount)     weight += 0.03  // last place
+  if (ctx.federalBribeActive)                   weight -= 0.015 // ongoing fed bribe
+  if (ctx.cityBribed)                           weight -= 0.01  // active city bribe
+  return Math.random() < Math.max(0.005, weight)
+}
+
+/** Fine cost: 25% of cash, minimum $150. */
+export function calculateFedFineCost(cash: number): number {
+  return Math.max(150, Math.floor(cash * 0.25))
+}
+
+/** Jail seasons for a fed stop: 1 minimum, +1 per 4 cargo units, max 8. */
+export function calculateFedJailTime(cargoUnits: number): number {
+  return Math.min(8, Math.max(1, 1 + Math.floor(cargoUnits / 4)))
 }

--- a/src/routes/games.ts
+++ b/src/routes/games.ts
@@ -8,7 +8,9 @@ import { generateRoads, buildGraph, getShortestPath } from '../game/mapEngine'
 import { DISTILLERY_TIERS, getUpgradeCost } from '../game/production'
 import {
   rollPoliceEncounter, resolveSubmit, resolveBribe, resolveRun,
-  calculateHeatIncrease, calculateSpotBribeCost, calculateLongTermBribeCost, type PopulationTier
+  calculateHeatIncrease, calculateSpotBribeCost, calculateLongTermBribeCost,
+  rollFedStop, calculateFedFineCost, calculateFedJailTime,
+  type PopulationTier
 } from '../game/police'
 import { applyBribeDuration, applyMovementModifier, applyCargoMultiplier, applyTakeoverCostModifier, applyProductionModifier, getCharacter } from '../game/characters'
 import { runNpcTurn } from '../game/npc'
@@ -499,6 +501,7 @@ gamesRouter.post('/:id/turn', async (c) => {
     `SELECT gp.id, gp.turn_order, gp.current_city_id, gp.character_class,
             gp.heat, gp.pending_police_encounter, gp.cash, gp.turn_started_at,
             gp.stuck_until_season, COALESCE(gp.display_name, u.email) AS display_name,
+            gp.role, gp.jailed_count, gp.federal_bribe_expires_season,
             g.current_player_index, g.current_season, g.total_seasons, g.status, g.player_count, g.max_players
      FROM game_players gp
      JOIN games g ON g.id = gp.game_id
@@ -509,6 +512,7 @@ gamesRouter.post('/:id/turn', async (c) => {
     character_class: string; heat: number; cash: number; turn_started_at: string | null
     pending_police_encounter: string | null
     stuck_until_season: number | null; display_name: string | null
+    role: string; jailed_count: number; federal_bribe_expires_season: number | null
     current_player_index: number; current_season: number; total_seasons: number; status: string; player_count: number; max_players: number
   }>()
 
@@ -548,7 +552,9 @@ gamesRouter.post('/:id/turn', async (c) => {
     alcoholType?: string; quantity?: number; vehicleId?: number; choice?: string; duration?: number
     vehicles?: Array<{ vehicleId: number; targetPath: number[]; allocatedPoints: number }>
   }
-  let policeEncounterResult: { vehicleId?: number; bribeCost: number; populationTier: string; heat: number } | null = null
+  type EncounterEntry = { vehicleId?: number; bribeCost: number; populationTier: string; heat: number; encounterType?: 'local' | 'fed'; fineCost?: number; jailSeasons?: number; cargoUnits?: number }
+  let policeEncounterResult: EncounterEntry | null = null
+  let fedEncounterResult: { fineCost: number; jailSeasons: number; cargoUnits: number } | null = null
   const celebrations: Array<{ type: string; cityId?: number; newTier?: number; vehicleId?: string; vehicleDbId?: number; vehicleType?: string; missionCardId?: number; reward?: number; repairCost?: number; units?: number; alcoholType?: string }> = []
   const boughtThisTurn = new Map<number, number>()
 
@@ -572,9 +578,7 @@ gamesRouter.post('/:id/turn', async (c) => {
 
     // ── Police resolve (must be first — clears pending and then ends turn) ────
     if (action.type === 'police_resolve' && playerRow.pending_police_encounter) {
-      const queue = JSON.parse(playerRow.pending_police_encounter) as Array<{
-        vehicleId?: number; bribeCost: number; populationTier: PopulationTier; heat: number
-      }>
+      const queue = JSON.parse(playerRow.pending_police_encounter) as EncounterEntry[]
       if (queue.length === 0) continue
       const encounter = queue.shift()!
       const choice = action.choice as 'submit' | 'bribe' | 'run'
@@ -641,7 +645,7 @@ gamesRouter.post('/:id/turn', async (c) => {
         } else {
           const jailUntil = playerRow.current_season + rr.jailSeasons
           await c.env.PROHIBITIONDB.prepare(
-            `UPDATE game_players SET heat = ?, jail_until_season = ?, pending_police_encounter = ? WHERE id = ?`
+            `UPDATE game_players SET heat = ?, jail_until_season = ?, jailed_count = jailed_count + 1, pending_police_encounter = ? WHERE id = ?`
           ).bind(newHeat, jailUntil, remaining2, playerRow.id).run()
           await updateCumulativeProgress(c.env.PROHIBITIONDB, playerRow.id, { type: 'jailed' })
         }
@@ -650,7 +654,76 @@ gamesRouter.post('/:id/turn', async (c) => {
       // If more encounters pending, return the next one
       if (queue.length > 0) {
         const next = queue[0]
-        policeEncounterResult = { vehicleId: next.vehicleId, bribeCost: next.bribeCost, populationTier: next.populationTier, heat: next.heat }
+        if (next.encounterType === 'fed') {
+          fedEncounterResult = { fineCost: next.fineCost!, jailSeasons: next.jailSeasons!, cargoUnits: next.cargoUnits! }
+        } else {
+          policeEncounterResult = next
+        }
+      }
+      // Fall through to turn advance
+    }
+
+    // ── Fed stop resolve ──────────────────────────────────────────────────────
+    if (action.type === 'fed_stop_respond' && playerRow.pending_police_encounter) {
+      const queue = JSON.parse(playerRow.pending_police_encounter) as EncounterEntry[]
+      if (queue.length === 0) continue
+      const encounter = queue.shift()!
+      if (encounter.encounterType !== 'fed') continue
+
+      const freshRow = await c.env.PROHIBITIONDB.prepare(
+        `SELECT cash, heat FROM game_players WHERE id = ?`
+      ).bind(playerRow.id).first<{ cash: number; heat: number }>()
+      const freshCash = freshRow?.cash ?? 0
+      const freshHeat = freshRow?.heat ?? 0
+      const remaining2 = queue.length > 0 ? JSON.stringify(queue) : null
+      const choice = action.choice as 'pay' | 'jail' | 'snitch'
+      const displayName = (playerRow.display_name ?? 'Someone').replace(/@.*$/, '')
+
+      if (choice === 'pay') {
+        const fine = Math.min(encounter.fineCost!, freshCash)
+        const newHeat = Math.max(0, freshHeat - 5)
+        await c.env.PROHIBITIONDB.prepare(
+          `UPDATE game_players SET cash = cash - ?, heat = ?, pending_police_encounter = ? WHERE id = ?`
+        ).bind(fine, newHeat, remaining2, playerRow.id).run()
+        addLedger('fed_fine', -fine, 'Paid federal fine', playerRow.current_city_id)
+        await c.env.PROHIBITIONDB.prepare(
+          `INSERT INTO game_messages (game_id, player_id, message, is_system) VALUES (?, ?, ?, 1)`
+        ).bind(gameId, playerRow.id, `🕵️ ${displayName} paid a federal fine.`).run()
+
+      } else if (choice === 'jail') {
+        const newHeat = Math.max(0, freshHeat - 10)
+        const jailUntil = playerRow.current_season + (encounter.jailSeasons ?? 1)
+        await c.env.PROHIBITIONDB.prepare(
+          `UPDATE game_players SET heat = ?, jail_until_season = ?, jailed_count = jailed_count + 1, pending_police_encounter = ? WHERE id = ?`
+        ).bind(newHeat, jailUntil, remaining2, playerRow.id).run()
+        await updateCumulativeProgress(c.env.PROHIBITIONDB, playerRow.id, { type: 'jailed' })
+        addLedger('fed_jail', 0, 'Taken in by federal agents', playerRow.current_city_id)
+        await c.env.PROHIBITIONDB.prepare(
+          `INSERT INTO game_messages (game_id, player_id, message, is_system) VALUES (?, ?, ?, 1)`
+        ).bind(gameId, playerRow.id, `🕵️ ${displayName} was taken in by federal agents.`).run()
+
+      } else if (choice === 'snitch') {
+        await c.env.PROHIBITIONDB.prepare(
+          `UPDATE game_players SET role = 'snitch', pending_police_encounter = ? WHERE id = ?`
+        ).bind(remaining2, playerRow.id).run()
+        // Create 4 unplaced informants
+        await c.env.PROHIBITIONDB.batch([
+          c.env.PROHIBITIONDB.prepare(`INSERT INTO informants (game_id, snitch_id) VALUES (?, ?)`).bind(gameId, playerRow.id),
+          c.env.PROHIBITIONDB.prepare(`INSERT INTO informants (game_id, snitch_id) VALUES (?, ?)`).bind(gameId, playerRow.id),
+          c.env.PROHIBITIONDB.prepare(`INSERT INTO informants (game_id, snitch_id) VALUES (?, ?)`).bind(gameId, playerRow.id),
+          c.env.PROHIBITIONDB.prepare(`INSERT INTO informants (game_id, snitch_id) VALUES (?, ?)`).bind(gameId, playerRow.id),
+        ])
+        // No public announcement — silent flip
+      }
+
+      playerRow.pending_police_encounter = remaining2
+      if (queue.length > 0) {
+        const next = queue[0]
+        if (next.encounterType === 'fed') {
+          fedEncounterResult = { fineCost: next.fineCost!, jailSeasons: next.jailSeasons!, cargoUnits: next.cargoUnits! }
+        } else {
+          policeEncounterResult = next
+        }
       }
       // Fall through to turn advance
     }
@@ -727,16 +800,52 @@ gamesRouter.post('/:id/turn', async (c) => {
           const bribeCost = calculateSpotBribeCost(currentHeat, tier)
           // Append to encounter queue
           const existing = playerRow.pending_police_encounter
-            ? JSON.parse(playerRow.pending_police_encounter) as Array<{ vehicleId: number; bribeCost: number; populationTier: string; heat: number }>
+            ? JSON.parse(playerRow.pending_police_encounter) as EncounterEntry[]
             : []
-          existing.push({ vehicleId: vehicleRow.id, bribeCost, populationTier: tier, heat: currentHeat })
+          existing.push({ vehicleId: vehicleRow.id, bribeCost, populationTier: tier, heat: currentHeat, encounterType: 'local' })
           const newJson = JSON.stringify(existing)
           await c.env.PROHIBITIONDB.prepare(
             `UPDATE game_players SET pending_police_encounter = ? WHERE id = ?`
           ).bind(newJson, playerRow.id).run()
           playerRow.pending_police_encounter = newJson
-          if (!policeEncounterResult) {
-            policeEncounterResult = { vehicleId: vehicleRow.id, bribeCost, populationTier: tier, heat: currentHeat }
+          if (!policeEncounterResult && !fedEncounterResult) {
+            policeEncounterResult = { vehicleId: vehicleRow.id, bribeCost, populationTier: tier, heat: currentHeat, encounterType: 'local' }
+          }
+        }
+
+        // Federal Stop roll — flat probability weighted by desperation, bypasses city bribe protection
+        {
+          const allPlayers = await c.env.PROHIBITIONDB.prepare(
+            `SELECT id, cash FROM game_players WHERE game_id = ? AND is_npc = 0 AND jail_until_season IS NULL ORDER BY cash DESC`
+          ).bind(gameId).all<{ id: number; cash: number }>()
+          const rankByWealth = (allPlayers.results.findIndex(p => p.id === playerRow.id) ?? 0) + 1
+          const playerCount = Math.max(1, allPlayers.results.length)
+          const cityCountRow = await c.env.PROHIBITIONDB.prepare(
+            `SELECT COUNT(*) AS cnt FROM game_cities WHERE game_id = ? AND owner_player_id = ?`
+          ).bind(gameId, playerRow.id).first<{ cnt: number }>()
+          const cityCount = cityCountRow?.cnt ?? 0
+          const fedBribeActive = playerRow.federal_bribe_expires_season != null &&
+            playerRow.federal_bribe_expires_season > playerRow.current_season
+
+          if (rollFedStop({
+            cityCount, cash: currentCash, jailedCount: playerRow.jailed_count,
+            rankByWealth, playerCount, federalBribeActive: fedBribeActive, cityBribed: cityIsBribed
+          })) {
+            const cargoUnits = vinv.reduce((s, r) => s + r.quantity, 0)
+            const fineCost = calculateFedFineCost(currentCash)
+            const jailSeasons = calculateFedJailTime(cargoUnits)
+            const fedQueue = playerRow.pending_police_encounter
+              ? JSON.parse(playerRow.pending_police_encounter) as EncounterEntry[]
+              : []
+            fedQueue.push({ bribeCost: 0, populationTier: 'small', heat: currentHeat, encounterType: 'fed', fineCost, jailSeasons, cargoUnits })
+            const fedJson = JSON.stringify(fedQueue)
+            await c.env.PROHIBITIONDB.prepare(
+              `UPDATE game_players SET pending_police_encounter = ? WHERE id = ?`
+            ).bind(fedJson, playerRow.id).run()
+            playerRow.pending_police_encounter = fedJson
+            if (!policeEncounterResult && !fedEncounterResult) {
+              fedEncounterResult = { fineCost, jailSeasons, cargoUnits }
+            }
           }
         }
       }
@@ -1349,7 +1458,11 @@ gamesRouter.post('/:id/turn', async (c) => {
     }
   }
 
-  // If a police encounter was triggered this turn, hold the turn until the player resolves it
+  // If an encounter was triggered this turn, hold the turn until the player resolves it
+  if (fedEncounterResult) {
+    await flushLedger()
+    return c.json({ success: true, fedEncounter: fedEncounterResult } as object)
+  }
   if (policeEncounterResult) {
     await flushLedger()
     return c.json({ success: true, policeEncounter: policeEncounterResult } as object)
@@ -1357,7 +1470,7 @@ gamesRouter.post('/:id/turn', async (c) => {
 
   // Market/free actions (buy, sell, pickup, sell_city_stock, upgrade_*, claim_city, bribe_official)
   // do NOT end the turn — only move, stay, skip are terminal
-  const TERMINAL_ACTIONS = new Set(['move', 'stay', 'skip', 'police_resolve'])
+  const TERMINAL_ACTIONS = new Set(['move', 'stay', 'skip', 'police_resolve', 'fed_stop_respond'])
   const hasTerminal = (actions as Action[]).some(a => TERMINAL_ACTIONS.has(a.type))
   if (!hasTerminal) {
     await flushLedger()
@@ -1677,7 +1790,7 @@ gamesRouter.get('/:id/state', async (c) => {
     `SELECT gp.id, gp.turn_order, gp.character_class, gp.cash, gp.heat,
             gp.jail_until_season, gp.current_city_id, gp.home_city_id, gp.adjustment_cards,
             gp.pending_drinks, gp.pending_trap, gp.stuck_until_season, gp.tutorial_seen,
-            gp.total_cash_earned, gp.consecutive_clean_seasons
+            gp.total_cash_earned, gp.consecutive_clean_seasons, gp.role
      FROM game_players gp
      WHERE gp.game_id = ? AND gp.user_id = ?`
   ).bind(gameId, userId).first<{
@@ -1686,18 +1799,19 @@ gamesRouter.get('/:id/state', async (c) => {
     current_city_id: number | null; home_city_id: number | null; adjustment_cards: number;
     pending_drinks: string | null; pending_trap: string | null; stuck_until_season: number | null
     tutorial_seen: number; total_cash_earned: number; consecutive_clean_seasons: number
+    role: string
   }>()
   if (!player) return c.json({ success: false, message: 'Not in game' }, 403)
 
   const { results: players } = await c.env.PROHIBITIONDB.prepare(
     `SELECT gp.id, gp.turn_order, gp.character_class, gp.is_npc, gp.current_city_id, gp.cash,
-            gp.display_name, gp.turn_started_at, u.email
+            gp.display_name, gp.turn_started_at, gp.role, u.email
      FROM game_players gp LEFT JOIN users u ON gp.user_id = u.id
      WHERE gp.game_id = ? ORDER BY gp.turn_order`
   ).bind(gameId).all<{
     id: number; turn_order: number; character_class: string; is_npc: number;
     current_city_id: number | null; cash: number; display_name: string | null
-    turn_started_at: string | null; email: string | null
+    turn_started_at: string | null; email: string | null; role: string
   }>()
 
   const { results: vehicleRows } = await c.env.PROHIBITIONDB.prepare(
@@ -1863,16 +1977,26 @@ gamesRouter.get('/:id/state', async (c) => {
           assignedSeason: m.assigned_season,
         })),
         completedMissions: completedMissionsRow?.count ?? 0,
+        role: player.role ?? 'bootlegger',
       },
-      players: players.map(p => ({
-        id:            p.id,
-        turnOrder:     p.turn_order,
-        characterClass: p.character_class,
-        isNpc:         p.is_npc === 1,
-        currentCityId: p.current_city_id,
-        turnStartedAt: p.turn_started_at ?? null,
-        name:          p.display_name ?? (p.is_npc ? `NPC ${p.turn_order + 1}` : (p.email?.split('@')[0] ?? 'Player'))
-      })),
+      players: [...players]
+        .sort((a, b) => {
+          // Snitches always rank last on the scoreboard
+          const aSnitch = (a.role ?? 'bootlegger') === 'snitch' ? 1 : 0
+          const bSnitch = (b.role ?? 'bootlegger') === 'snitch' ? 1 : 0
+          if (aSnitch !== bSnitch) return aSnitch - bSnitch
+          return b.cash - a.cash
+        })
+        .map(p => ({
+          id:            p.id,
+          turnOrder:     p.turn_order,
+          characterClass: p.character_class,
+          isNpc:         p.is_npc === 1,
+          currentCityId: p.current_city_id,
+          turnStartedAt: p.turn_started_at ?? null,
+          role:          p.role ?? 'bootlegger',
+          name:          p.display_name ?? (p.is_npc ? `NPC ${p.turn_order + 1}` : (p.email?.split('@')[0] ?? 'Player'))
+        })),
       vehiclePrices: VEHICLE_PRICES,
       alliances: allianceRows.map(a => ({
         id:            a.id,


### PR DESCRIPTION
## Description
Implements the Federal Stop encounter and snitch recruitment path (issue #101, part of epic #99).

## Changes
- `src/game/police.ts`: `rollFedStop`, `calculateFedFineCost`, `calculateFedJailTime`, `FedStopContext`; `TIER_BRIBE_MULTIPLIER` now exported
- `src/routes/games.ts`: fed stop trigger in move handler; `fed_stop_respond` action (pay/jail/snitch); `jailed_count` tracking; snitch-last ranking in `/state`
- `src/frontend/src/components/FedStopDialog.tsx`: new navy/indigo dialog with two-step snitch confirm
- `src/frontend/src/pages/GamePage.tsx`: `fedEncounter` state; renders `FedStopDialog`

## Testing
- [x] Validation passes (248 tests, typecheck clean)

## Checklist
- [x] Architecture conventions respected
- [x] New functions added to police.ts (game logic module)
- [x] All tests pass locally

Closes #101