### PR TITLE
test(npc): NPC snitch auto-recruitment and accusation tests (#125)

### DIFF
--- a/src/game/npc.ts
+++ b/src/game/npc.ts
@@ -201,7 +201,7 @@ export async function runNpcTurn(
       `SELECT id FROM game_players WHERE game_id = ? AND is_npc = 1 ORDER BY cash DESC`
     ).bind(gameId).all<{ id: number }>()
     const isLastNpc = wealthRank.results[wealthRank.results.length - 1]?.id === npcId
-    if (isLastNpc && npcRow.cash < 300 && npcRow.jailed_count > 0) {
+    if (shouldNpcFlipToSnitch(npcRow.cash, npcRow.jailed_count, isLastNpc)) {
       await db.prepare(`UPDATE game_players SET role = 'snitch' WHERE id = ?`).bind(npcId).run()
       await db.batch([
         db.prepare(`INSERT INTO informants (game_id, snitch_id) VALUES (?, ?)`).bind(gameId, npcId),
@@ -244,10 +244,7 @@ export async function runNpcTurn(
         const { results: targetVehicles } = await db.prepare(
           `SELECT id, city_id FROM vehicles WHERE player_id = ?`
         ).bind(target.id).all<{ id: number; city_id: number }>()
-        const allPinned = targetVehicles.every(v =>
-          sightings.some(s => s.cityId === v.city_id)
-        )
-        if (allPinned && targetVehicles.length > 0) {
+        if (npcCanAccuse(sightings, targetVehicles.map(v => v.city_id))) {
           const alreadyAccused = await db.prepare(
             `SELECT id FROM snitch_accusations WHERE game_id = ? AND snitch_id = ? AND target_id = ? AND season = ?`
           ).bind(gameId, npcId, target.id, season).first()
@@ -540,6 +537,25 @@ async function tryUpgradeStill(
 }
 
 const BASE_CLAIM: Record<string, number> = { small: 500, medium: 1000, large: 1500, major: 2500 }
+
+/**
+ * Pure predicate: should this NPC flip to snitch role?
+ * Threshold: last-place NPC by cash AND cash < $300 AND at least one prior jail.
+ * Exported for unit testing.
+ */
+export function shouldNpcFlipToSnitch(cash: number, jailedCount: number, isLastNpc: boolean): boolean {
+  return isLastNpc && cash < 300 && jailedCount > 0
+}
+
+/**
+ * Pure predicate: can the NPC snitch file a valid accusation against a target?
+ * Requires >= 2 sightings and all of the target's vehicle city IDs pinned in those sightings.
+ * Exported for unit testing.
+ */
+export function npcCanAccuse(sightings: Array<{ cityId: number }>, vehicleCityIds: number[]): boolean {
+  if (sightings.length < 2 || vehicleCityIds.length === 0) return false
+  return vehicleCityIds.every(cityId => sightings.some(s => s.cityId === cityId))
+}
 
 /**
  * Pure cost calculation for NPC city takeovers — mirrors human claim_city logic.

--- a/tests/npc.test.ts
+++ b/tests/npc.test.ts
@@ -5,6 +5,8 @@ import {
   selectNpcAction,
   computeNpcTakeoverCost,
   selectNpcTarget,
+  shouldNpcFlipToSnitch,
+  npcCanAccuse,
   type NpcState,
   type NpcAction
 } from '../src/game/npc'
@@ -149,5 +151,53 @@ describe('computeNpcTakeoverCost()', () => {
   it('owned city uses stored claim_cost (ignores BASE_CLAIM)', () => {
     // claim_cost = 1500, neutral=false → 2 × 1500 = 3000
     expect(computeNpcTakeoverCost(1500, 'large', 1, false)).toBe(3000)
+  })
+})
+
+describe('shouldNpcFlipToSnitch()', () => {
+  it('returns false when NPC is not last place, even if broke and jailed', () => {
+    expect(shouldNpcFlipToSnitch(100, 2, false)).toBe(false)
+  })
+
+  it('returns false when cash >= $300, even if last place and jailed', () => {
+    expect(shouldNpcFlipToSnitch(300, 1, true)).toBe(false)
+  })
+
+  it('returns false when jailed_count = 0, even if last place and broke', () => {
+    expect(shouldNpcFlipToSnitch(100, 0, true)).toBe(false)
+  })
+
+  it('returns true when last-place NPC, cash < $300, and jailed_count > 0', () => {
+    expect(shouldNpcFlipToSnitch(299, 1, true)).toBe(true)
+  })
+
+  it('returns false when cash is exactly $300 (boundary — not below)', () => {
+    expect(shouldNpcFlipToSnitch(300, 2, true)).toBe(false)
+  })
+})
+
+describe('npcCanAccuse()', () => {
+  it('returns false when fewer than 2 sightings', () => {
+    expect(npcCanAccuse([{ cityId: 1 }], [1])).toBe(false)
+  })
+
+  it('returns false when sightings exist but target vehicle city not in sightings', () => {
+    const sightings = [{ cityId: 1 }, { cityId: 2 }]
+    expect(npcCanAccuse(sightings, [1, 3])).toBe(false)
+  })
+
+  it('returns false when vehicleCityIds is empty (no vehicles to pin)', () => {
+    const sightings = [{ cityId: 1 }, { cityId: 2 }]
+    expect(npcCanAccuse(sightings, [])).toBe(false)
+  })
+
+  it('returns true when >= 2 sightings and all vehicle city IDs are pinned', () => {
+    const sightings = [{ cityId: 5 }, { cityId: 7 }]
+    expect(npcCanAccuse(sightings, [5, 7])).toBe(true)
+  })
+
+  it('returns true when sightings contain superset of vehicle cities', () => {
+    const sightings = [{ cityId: 1 }, { cityId: 2 }, { cityId: 3 }]
+    expect(npcCanAccuse(sightings, [2])).toBe(true)
   })
 })


### PR DESCRIPTION
## Description
Extracts two pure predicates from `runNpcTurn` and adds 10 unit tests covering all boundary conditions for NPC snitch mechanics.

## Changes
- `shouldNpcFlipToSnitch(cash, jailedCount, isLastNpc)` — pure export, replaces inline condition in auto-recruitment block
- `npcCanAccuse(sightings, vehicleCityIds)` — pure export, replaces inline `allPinned` check in accusation loop
- `tests/npc.test.ts` — 10 new tests: 5 for flip threshold, 5 for accusation readiness

## Testing
- [x] 268 tests pass
- [x] Typecheck clean

## Checklist
- [x] Architecture conventions respected
- [x] Pure helpers exported for testability
- [x] All tests pass locally

Closes #125