### PR TITLE
feat(db): Chicago and Philadelphia produce scotch

### DIFF
--- a/migrations/0046_chicago_philly_scotch.sql
+++ b/migrations/0046_chicago_philly_scotch.sql
@@ -1,0 +1,7 @@
+-- Chicago and Philadelphia are major cities producing beer, which violates the
+-- tier rule (major → gin/scotch only at the top). Reassign both to scotch —
+-- the highest-value type ($35 base) and the only two cities that produce it,
+-- making them genuinely worth their major-city acquisition cost.
+
+UPDATE city_pool SET primary_alcohol = 'scotch' WHERE name = 'Chicago';
+UPDATE city_pool SET primary_alcohol = 'scotch' WHERE name = 'Philadelphia';


### PR DESCRIPTION
Chicago and Philadelphia are major cities assigned beer, violating the premium tier rules established in #132. Reassign both to scotch — the highest-value type and now exclusive to two cities.